### PR TITLE
Add mp4 extension to videos

### DIFF
--- a/frontend/src/lib/admin.svelte
+++ b/frontend/src/lib/admin.svelte
@@ -103,6 +103,14 @@ SPDX-License-Identifier: MPL-2.0
 			timer_res = seconds.toString();
 		}, 1000);
 	};
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 {#if control_visible}
@@ -192,7 +200,7 @@ SPDX-License-Identifier: MPL-2.0
 							<!-- svelte-ignore a11y-media-has-caption -->
 							<video
 								class="max-h-full max-w-full block"
-								src={`/api/v1/storage/download/${quiz_data.cover_image}`}
+								src={getVideoUrl(`/api/v1/storage/download/${quiz_data.cover_image}`)}
 								controls
 							>
 								Your browser does not support the video tag.

--- a/frontend/src/lib/dashboard/main_slider.svelte
+++ b/frontend/src/lib/dashboard/main_slider.svelte
@@ -77,6 +77,14 @@ SPDX-License-Identifier: MPL-2.0
 		get_game_in_lobby_fn();
 		fetchContentTypes();
 	});
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 {#if copy_toast_open || game_in_lobby}
@@ -187,7 +195,7 @@ SPDX-License-Identifier: MPL-2.0
 														<!-- svelte-ignore a11y-media-has-caption -->
 														<video
 															class="max-h-full max-w-full block"
-															src={`/api/v1/storage/download/${quiz.cover_image}`}
+															src={getVideoUrl(`/api/v1/storage/download/${quiz.cover_image}`)}
 															controls
 														>
 															Your browser does not support the video tag.

--- a/frontend/src/lib/editor/MediaComponent.svelte
+++ b/frontend/src/lib/editor/MediaComponent.svelte
@@ -60,12 +60,20 @@ SPDX-License-Identifier: MPL-2.0
 		}
 		fullscreen_open = true;
 	};
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 {#await media}
 	<img src={thumbhash_data} class={`${css_classes} ${added_thumbhash_classes}`} />
 {:then data}
 	{#if type === 'img'}
+		<!-- svelte-ignore a11y-click-events-have-key-events -->
 		<img
 			in:fade={{ duration: 300 }}
 			src={img_data.data}
@@ -77,14 +85,13 @@ SPDX-License-Identifier: MPL-2.0
 		<video
 			class={css_classes}
 			disablepictureinpicture
-			x-webkit-airplay="deny"
 			controls
 			autoplay
 			loop
 			{muted}
 			preload="metadata"
 		>
-			<source src="/api/v1/storage/download/{src}" />
+			<source src={getVideoUrl(`/api/v1/storage/download/${src}`)} />			
 		</video>
 	{:else}
 		<p>Unknown media type</p>
@@ -92,6 +99,7 @@ SPDX-License-Identifier: MPL-2.0
 {/await}
 
 {#if fullscreen_open}
+	<!-- svelte-ignore a11y-click-events-have-key-events -->
 	<div
 		class="fixed top-0 left-0 z-50 w-screen h-screen bg-black bg-opacity-50 fle p-2"
 		transition:fade={{ duration: 80 }}

--- a/frontend/src/lib/editor/settings-card.svelte
+++ b/frontend/src/lib/editor/settings-card.svelte
@@ -50,6 +50,14 @@ SPDX-License-Identifier: MPL-2.0
 	onMount(async () => {
 		await fetchContentTypes();
 	});
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 <div class="w-full h-full pb-20 px-20">
@@ -108,7 +116,7 @@ SPDX-License-Identifier: MPL-2.0
 					{:else if contentTypes[data.cover_image]?.startsWith('video')}
 						<!-- svelte-ignore a11y-media-has-caption -->
 						<video
-							src="/api/v1/storage/download/{data.cover_image}"
+							src={getVideoUrl(`/api/v1/storage/download/${data.cover_image}`)}
 							controls
 							class="max-h-72 h-auto w-auto"
 							on:contextmenu|preventDefault={() => {

--- a/frontend/src/lib/editor/sidebar.svelte
+++ b/frontend/src/lib/editor/sidebar.svelte
@@ -85,6 +85,14 @@ SPDX-License-Identifier: MPL-2.0
 	onMount(async () => {
 		await fetchContentTypes();
 	});
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 <div class="h-screen relative">
@@ -315,7 +323,7 @@ SPDX-License-Identifier: MPL-2.0
 						{#if contentTypes[question.image] === 'video/mp4'}
 							<!-- svelte-ignore a11y-media-has-caption -->
 							<video
-								src="/api/v1/storage/download/{question.image}"
+								src={getVideoUrl(`/api/v1/storage/download/${question.image}`)}
 								class="h-10 border rounded-lg"
 								controls
 								use:tippy={{

--- a/frontend/src/lib/editor/uploader/Library.svelte
+++ b/frontend/src/lib/editor/uploader/Library.svelte
@@ -56,6 +56,14 @@ SPDX-License-Identifier: MPL-2.0
 		const images = await image_fetch;
 		fetchContentTypes(images);
 	});
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 {#await image_fetch}
@@ -78,7 +86,7 @@ SPDX-License-Identifier: MPL-2.0
 						{:else if contentTypes[image.id]?.startsWith('video')}
 							<!-- svelte-ignore a11y-media-has-caption -->
 							<video
-								src={`/api/v1/storage/download/${image.id}`}
+								src={getVideoUrl(`/api/v1/storage/download/${image.id}`)}
 								controls
 								class="object-contain w-full h-full max-h-full rounded"
 							>

--- a/frontend/src/lib/play/title.svelte
+++ b/frontend/src/lib/play/title.svelte
@@ -24,6 +24,14 @@ SPDX-License-Identifier: MPL-2.0
 			contentType = await fetchContentType(`/api/v1/storage/download/${cover_image}`);
 		}
 	});
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 <div class="flex flex-col justify-center w-screen h-screen">
@@ -42,7 +50,7 @@ SPDX-License-Identifier: MPL-2.0
 					<!-- svelte-ignore a11y-media-has-caption -->
 					<video
 						class="max-h-full max-w-full block"
-						src={`/api/v1/storage/download/${cover_image}`}
+						src={getVideoUrl(`/api/v1/storage/download/${cover_image}`)}
 						controls
 					>
 						Your browser does not support the video tag.

--- a/frontend/src/lib/practice/title_screen.svelte
+++ b/frontend/src/lib/practice/title_screen.svelte
@@ -26,6 +26,14 @@ SPDX-License-Identifier: MPL-2.0
 			contentType = await fetchContentType(`/api/v1/storage/download/${data.cover_image}`);
 		}
 	});
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 <div class="w-full px-6 lg:px-20 h-[80vh] absolute" in:fly={{ x: 100 }} out:fly={{ x: -100 }}>
@@ -73,7 +81,7 @@ SPDX-License-Identifier: MPL-2.0
 					{:else if contentType?.startsWith('video')}
 						<!-- svelte-ignore a11y-media-has-caption -->
 						<video
-							src={`/api/v1/storage/download/${data.cover_image}`}
+							src={getVideoUrl(`/api/v1/storage/download/${data.cover_image}`)}
 							class="max-h-72 h-auto w-auto"
 							controls
 							on:contextmenu|preventDefault={() => {

--- a/frontend/src/routes/edit/files/+page.svelte
+++ b/frontend/src/routes/edit/files/+page.svelte
@@ -63,6 +63,14 @@ SPDX-License-Identifier: MPL-2.0
 		});
 		await Promise.all(promises);
 	}
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 <div>
@@ -90,7 +98,7 @@ SPDX-License-Identifier: MPL-2.0
 				{:else if contentTypes[image.id]?.startsWith('video')}
 					<!-- svelte-ignore a11y-media-has-caption -->
 					<video
-						src={`/api/v1/storage/download/${image.id}`}
+						src={getVideoUrl(`/api/v1/storage/download/${image.id}`)}
 						class="m-auto h-auto w-auto max-h-[30vh]"
 						controls
 					>

--- a/frontend/src/routes/moderation/+page.svelte
+++ b/frontend/src/routes/moderation/+page.svelte
@@ -32,6 +32,14 @@ SPDX-License-Identifier: MPL-2.0
 	onMount(() => {
 		fetchContentTypes();
 	});
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 <div class="flex flex-col p-2">
@@ -50,7 +58,7 @@ SPDX-License-Identifier: MPL-2.0
 						{:else if contentTypes[quiz.cover_image]?.startsWith('video')}
 							<!-- svelte-ignore a11y-media-has-caption -->
 							<video
-								src={`/api/v1/storage/download/${quiz.cover_image}`}
+								src={getVideoUrl(`/api/v1/storage/download/${quiz.cover_image}`)}
 								class="shrink-0 max-w-full max-h-full absolute rounded"
 								controls
 							>

--- a/frontend/src/routes/user/[user_id]/+page.svelte
+++ b/frontend/src/routes/user/[user_id]/+page.svelte
@@ -50,6 +50,14 @@ SPDX-License-Identifier: MPL-2.0
 		});
 		await Promise.all(promises);
 	}
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 <svelte:head>
@@ -111,7 +119,7 @@ SPDX-License-Identifier: MPL-2.0
 												<!-- svelte-ignore a11y-media-has-caption -->
 												<video
 													class="max-h-full max-w-full block"
-													src={`/api/v1/storage/download/${quiz.cover_image}`}
+													src={getVideoUrl(`/api/v1/storage/download/${quiz.cover_image}`)}
 													controls
 												>
 													Your browser does not support the video tag.

--- a/frontend/src/routes/view/[quiz_id]/+page.svelte
+++ b/frontend/src/routes/view/[quiz_id]/+page.svelte
@@ -89,6 +89,14 @@ SPDX-License-Identifier: MPL-2.0
             contentType = await fetchContentType(`/api/v1/storage/download/${quiz.cover_image}`);
         }
     });
+
+	// Function to ensure the .mp4 extension is present
+	function getVideoUrl(url) {
+    	if (!url.endsWith('.mp4')) {
+      		return `${url}.mp4`;
+    	}
+    	return url;
+  	}
 </script>
 
 <svelte:head>
@@ -119,7 +127,7 @@ SPDX-License-Identifier: MPL-2.0
                     <!-- svelte-ignore a11y-media-has-caption -->
                     <video
                         class="max-h-full max-w-full block"
-                        src={`/api/v1/storage/download/${quiz.cover_image}`}
+                        src={getVideoUrl(`/api/v1/storage/download/${quiz.cover_image}`)}
                         controls
                     >
                         Your browser does not support the video tag.


### PR DESCRIPTION
This PR attempts to make Safari on Apple devices recognize and reproduce mp4 videos by adding the mp4 extension.

This adjusts the download endpoint to accept the mp4 extension and return the file, including the extension.