### PR TITLE
Automatically Show First Question on Game Start

### DIFF
--- a/classquiz/socket_server/__init__.py
+++ b/classquiz/socket_server/__init__.py
@@ -232,6 +232,9 @@ async def start_game(sid: str, _data: dict):
     await redis.delete(f"game_in_lobby:{game_data.user_id.hex}")
     await sio.emit("start_game", room=session["game_pin"])
 
+    # Automatically set the first question
+    await set_question_number(sid, '0')
+
 
 class _RegisterAsAdminData(BaseModel):
     game_pin: str

--- a/frontend/src/lib/play/admin/controls.svelte
+++ b/frontend/src/lib/play/admin/controls.svelte
@@ -42,6 +42,14 @@ SPDX-License-Identifier: MPL-2.0
 	const get_final_results = () => {
 		socket.emit('get_final_results', {});
 	};
+
+	socket.on('set_question_number', ({ question_index }) => {
+        selected_question = question_index;
+    });
+
+    socket.on('start_game', () => {
+        set_question_number(0);
+    });
 </script>
 
 <div


### PR DESCRIPTION
This PR introduces functionality to automatically display the first question when a game starts. It ensures a smooth transition from the lobby to the first question, enhancing the user experience.

**Changes Made:**
1. **Backend (Python):**
   - Modified `start_game` event in `classquiz/socket_server/__init__.py` to automatically set the first question by calling `set_question_number` with the index `0`.

2. **Frontend (Svelte):**
   - Added socket event listeners in `controls.svelte` to handle `set_question_number` and `start_game` events, ensuring the first question is shown when the game starts.

These changes should make the transition from the game lobby to the first question seamless and intuitive for users. 