### PR TITLE
Display Correct Order for Order Activity

### DIFF
--- a/frontend/src/lib/play/admin/order_results.svelte
+++ b/frontend/src/lib/play/admin/order_results.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import type { Question } from '$lib/quiz_types';
+
+	export let data;
+	export let question: Question;
+
+	let quiz_answers = [];
+
+	for (const i of question.answers) {
+		quiz_answers.push(i.answer);
+	}
+</script>
+
+<div class="flex justify-center w-full p-4">
+	<div class="flex flex-col w-full max-w-2xl bg-white dark:bg-gray-800 shadow-lg rounded-lg p-4">
+		<h2 class="text-xl font-bold text-center mb-4 dark:text-white">Correct Answers in Order</h2>
+		<div class="flex flex-col gap-2">
+			{#each quiz_answers as answer, i}
+				<div class="flex items-center bg-gray-100 dark:bg-gray-700 rounded p-2">
+					<div class="flex-shrink-0 w-8 h-8 rounded-full bg-blue-500 dark:bg-blue-700 text-white flex items-center justify-center font-bold mr-4">
+						{i + 1}
+					</div>
+					<p class="flex-grow text-black dark:text-white">{@html answer}</p>
+				</div>
+			{/each}
+		</div>
+	</div>
+</div>

--- a/frontend/src/lib/play/admin/results.svelte
+++ b/frontend/src/lib/play/admin/results.svelte
@@ -6,6 +6,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <script lang="ts">
 	import VotingResults from './voting_results.svelte';
+	import OrderResults from './order_results.svelte';
 	import { flip } from 'svelte/animate';
 	import { fly } from 'svelte/transition';
 	import { onMount } from 'svelte';
@@ -132,6 +133,11 @@ SPDX-License-Identifier: MPL-2.0
 	{#if [QuizQuestionType.ABCD, QuizQuestionType.VOTING, QuizQuestionType.TEXT].includes(question.type)}
 		<div class="mt-12">
 			<VotingResults data={new_data} {question} />
+		</div>
+	{/if}
+	{#if [QuizQuestionType.ORDER]}
+		<div class="mt-12">
+			<OrderResults data={new_data} {question} />
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
This PR adds a new feature to display the correct order of quiz answers in a visually appealing and responsive format. The component adapts to both light and dark modes.

### Changes:
- **New Component**: Added `OrderResults` component to display answers in the correct order.
- **Responsive Design**: Ensured the component is responsive and visually consistent across devices.
- **Dark Mode Support**: Implemented dark mode support for better readability.

#### Files Modified:
- `frontend/src/lib/play/admin/order_results.svelte`: Added the new `OrderResults` component.
- `frontend/src/lib/play/admin/results.svelte`: Integrated `OrderResults` component into the results display logic.

This enhancement improves the quiz experience by clearly showcasing the correct answer order with visual aids and responsiveness.