### PR TITLE
Fix Background and UI Overlaps in Game Modal and Question Display

### DIFF
--- a/frontend/src/lib/admin.svelte
+++ b/frontend/src/lib/admin.svelte
@@ -121,6 +121,15 @@ SPDX-License-Identifier: MPL-2.0
   	}
 </script>
 
+{#if timer_res !== '0' && selected_question >= 0}
+	<span
+		class=" block bg-red-500 h-8 transition-all"
+		
+		style="width: {(100 / parseInt(quiz_data.questions[selected_question].time)) *
+			parseInt(timer_res)}vw"
+	/>
+{/if}
+
 {#if control_visible}
 	<Controls
 		{bg_color}
@@ -135,14 +144,7 @@ SPDX-License-Identifier: MPL-2.0
 		{shown_question_now}
 	/>
 {/if}
-{#if timer_res !== '0' && selected_question >= 0}
-	<span
-		class="fixed top-0 bg-red-500 h-8 transition-all"
-		class:mt-10={control_visible}
-		style="width: {(100 / parseInt(quiz_data.questions[selected_question].time)) *
-			parseInt(timer_res)}vw"
-	/>
-{/if}
+
 
 <div class="w-full h-full" class:pt-28={control_visible} class:pt-12={!control_visible}>
 	{#if timer_res !== undefined && !final_results_clicked && !question_results}

--- a/frontend/src/lib/admin.svelte
+++ b/frontend/src/lib/admin.svelte
@@ -123,7 +123,7 @@ SPDX-License-Identifier: MPL-2.0
 
 {#if timer_res !== '0' && selected_question >= 0}
 	<span
-		class=" block bg-red-500 h-8 transition-all"
+		class="fixed top-0 bg-red-500 h-8 transition-all"
 		
 		style="width: {(100 / parseInt(quiz_data.questions[selected_question].time)) *
 			parseInt(timer_res)}vw"

--- a/frontend/src/lib/dashboard/start_game.svelte
+++ b/frontend/src/lib/dashboard/start_game.svelte
@@ -98,15 +98,16 @@ SPDX-License-Identifier: MPL-2.0
 </script>
 
 <div
-    class="absolute top-0 left-0 flex justify-center w-screen py-20 min-h-screen bg-black bg-opacity-60 z-50 text-black"
+    class="fixed inset-0 flex justify-center items-center w-screen h-screen overflow-auto bg-black bg-opacity-60 z-50 py-5 "
     transition:fade={{ duration: 100 }}
+    style="scrollbar-width: none;"
     on:click={on_parent_click}
 	on:keydown={() => {}}
 	on:keyup={() => {}}
 	on:keypress={() => {}}
 >
     <div
-        class="w-5/6 dark:!bg-gray-600 m-auto rounded-lg shadow-lg p-4 flex flex-col"
+        class="w-5/6 dark:!bg-gray-600 m-auto rounded-lg shadow-lg p-4 flex flex-col "
         style="background-color: {bg_color}"
     >
         <div class="grid md:grid-cols-2 grid-cols-1 md:gap-16 gap-10 my-10">

--- a/frontend/src/lib/editor/OrderEditorPart.svelte
+++ b/frontend/src/lib/editor/OrderEditorPart.svelte
@@ -52,7 +52,7 @@ SPDX-License-Identifier: MPL-2.0
 			id: [i]
 		};
 	}
-	const default_colors = ['#C8E6C9', '#FFE0B2', '#FFF9C4', '#B3E5FC'];
+	const default_colors = ['#FFA800', '#00A3FF', '#FF1D38', '#00D749'];
 	const set_colors_if_unset = () => {
 		for (let i = 0; i < data.questions[selected_question].answers.length; i++) {
 			if (!data.questions[selected_question].answers[i].color) {

--- a/frontend/src/lib/play/admin/check_range.svelte
+++ b/frontend/src/lib/play/admin/check_range.svelte
@@ -19,8 +19,8 @@
   
   <div class="flex justify-center w-full px-4">
     <div class="m-auto gap-4 flex flex-col items-center">
-      <h2 class="text-2xl font-bold text-center mb-4 dark:text-white">Range Results</h2>
-      <p class="text-lg md:text-xl lg:text-2xl text-center mb-6 dark:text-gray-300 text-gray-700">{question.question}</p>
+      <h2 class="text-2xl font-bold text-center text-white mb-4 dark:text-white">Range Results</h2>
+      <p class="text-lg md:text-xl lg:text-2xl text-center mb-6 text-white dark:text-gray-300 text-gray-700">{question.question}</p>
       <div class="flex flex-wrap justify-center gap-4 w-full max-w-5xl">
         {#each data as item, i}
           <div class="w-full md:w-1/2 lg:w-1/3 p-4">

--- a/frontend/src/lib/play/admin/controls.svelte
+++ b/frontend/src/lib/play/admin/controls.svelte
@@ -61,11 +61,11 @@ SPDX-License-Identifier: MPL-2.0
 	style="background: {bg_color ? bg_color : 'transparent'}"
 	class:text-black={bg_color}
 >
-	<p class="fixed top-10 left-10 z-50 mr-auto ml-0 col-start-1 col-end-1 flex items-center italic justify-center font-semibold bg-white text-black dark:text-black rounded-full w-20 border-8 border-[#0AEDFE] h-20">
+	<p class=" top-10 left-10 z-50 mr-auto ml-0 col-start-1 col-end-1 flex items-center italic justify-center font-semibold bg-white text-black dark:text-black rounded-full w-20 border-8 border-[#0AEDFE] h-20">
 		{selected_question === -1 ? '0' : selected_question + 1}
 		/ {quiz_data.questions.length}
 	</p>
-	<div class="fixed top-4 right-20 z-50 flex flex-col items-center space-y-4">
+	<div class=" top-4 right-20 z-50 flex flex-col items-end space-y-4">
 		{#if selected_question + 1 === quiz_data.questions.length && ((timer_res === '0' && question_results !== null) || quiz_data?.questions?.[selected_question]?.type === QuizQuestionType.SLIDE)}
 		  {#if JSON.stringify(final_results) === JSON.stringify([null])}
 			<button on:click={get_final_results} class="slide-control-btn">

--- a/frontend/src/lib/play/admin/controls.svelte
+++ b/frontend/src/lib/play/admin/controls.svelte
@@ -61,11 +61,11 @@ SPDX-License-Identifier: MPL-2.0
 	style="background: {bg_color ? bg_color : 'transparent'}"
 	class:text-black={bg_color}
 >
-	<p class=" top-10 left-10 z-50 mr-auto ml-0 col-start-1 col-end-1 flex items-center italic justify-center font-semibold bg-white text-black dark:text-black rounded-full w-20 border-8 border-[#0AEDFE] h-20">
+	<p class="fixed top-10 left-10 z-50 mr-auto ml-0 col-start-1 col-end-1 flex items-center italic justify-center font-semibold bg-white text-black dark:text-black rounded-full w-20 border-8 border-[#0AEDFE] h-20">
 		{selected_question === -1 ? '0' : selected_question + 1}
 		/ {quiz_data.questions.length}
 	</p>
-	<div class=" top-4 right-20 z-50 flex flex-col items-end space-y-4">
+	<div class="fixed top-4 right-20 z-50 flex flex-col items-center space-y-4">
 		{#if selected_question + 1 === quiz_data.questions.length && ((timer_res === '0' && question_results !== null) || quiz_data?.questions?.[selected_question]?.type === QuizQuestionType.SLIDE)}
 		  {#if JSON.stringify(final_results) === JSON.stringify([null])}
 			<button on:click={get_final_results} class="slide-control-btn">

--- a/frontend/src/lib/play/admin/controls.svelte
+++ b/frontend/src/lib/play/admin/controls.svelte
@@ -65,7 +65,7 @@ SPDX-License-Identifier: MPL-2.0
 		{selected_question === -1 ? '0' : selected_question + 1}
 		/ {quiz_data.questions.length}
 	</p>
-	<div class="fixed top-4 right-20 z-50 flex flex-col items-center space-y-4">
+	<div class="fixed top-10 right-20 z-50 flex flex-col items-center space-y-4">
 		{#if selected_question + 1 === quiz_data.questions.length && ((timer_res === '0' && question_results !== null) || quiz_data?.questions?.[selected_question]?.type === QuizQuestionType.SLIDE)}
 		  {#if JSON.stringify(final_results) === JSON.stringify([null])}
 			<button on:click={get_final_results} class="slide-control-btn">
@@ -100,8 +100,8 @@ SPDX-License-Identifier: MPL-2.0
 			</button>
 		  {/if}
 		{/if}
-		<p class=" text-lg px-4 py-2 mx-3 mt-4 rounded-xl text-white">
+		<div class="text-sm px-4 py-2 mx-3 mt-4 rounded-xl text-white bg-black bg-opacity-20 shadow-lg">
 			{$t('admin_page.answers_submitted', { answer_count: answer_count })}
-		</p>
+		</div>		
 	  </div>
 </div>

--- a/frontend/src/lib/play/admin/controls.svelte
+++ b/frontend/src/lib/play/admin/controls.svelte
@@ -65,7 +65,7 @@ SPDX-License-Identifier: MPL-2.0
 		{selected_question === -1 ? '0' : selected_question + 1}
 		/ {quiz_data.questions.length}
 	</p>
-	<div class="fixed top-10 right-20 z-50 flex flex-col items-center space-y-4">
+	<div class="fixed top-10 right-0 px-4 z-50 flex flex-col items-center space-y-4">
 		{#if selected_question + 1 === quiz_data.questions.length && ((timer_res === '0' && question_results !== null) || quiz_data?.questions?.[selected_question]?.type === QuizQuestionType.SLIDE)}
 		  {#if JSON.stringify(final_results) === JSON.stringify([null])}
 			<button on:click={get_final_results} class="slide-control-btn">
@@ -100,7 +100,7 @@ SPDX-License-Identifier: MPL-2.0
 			</button>
 		  {/if}
 		{/if}
-		<div class="text-sm px-4 py-2 mx-3 mt-4 rounded-xl text-white bg-black bg-opacity-20 shadow-lg">
+		<div class="fixed right-0 top-20 text-sm px-4 py-2 mr-3 mt-4 rounded-xl text-white bg-black bg-opacity-20 shadow-lg">
 			{$t('admin_page.answers_submitted', { answer_count: answer_count })}
 		</div>		
 	  </div>

--- a/frontend/src/lib/play/admin/game_not_started.svelte
+++ b/frontend/src/lib/play/admin/game_not_started.svelte
@@ -133,7 +133,7 @@
 		<img
 			alt={$t('qr_code_to_join_the_game')}
 			src={`/api/v1/utils/qr/${game_pin}`}
-			class="object-contain rounded m-auto h-full bg-white"
+			class="object-contain rounded m-auto w-1/2  bg-white"
 		/>
 	</div>
 {/if}

--- a/frontend/src/lib/play/admin/game_not_started.svelte
+++ b/frontend/src/lib/play/admin/game_not_started.svelte
@@ -133,7 +133,7 @@
 		<img
 			alt={$t('qr_code_to_join_the_game')}
 			src={`/api/v1/utils/qr/${game_pin}`}
-			class="object-contain rounded m-auto w-1/2  bg-white"
+			class="object-contain rounded m-auto md:w-1/2 w-full  bg-white"
 		/>
 	</div>
 {/if}

--- a/frontend/src/lib/play/admin/question.svelte
+++ b/frontend/src/lib/play/admin/question.svelte
@@ -36,7 +36,7 @@ SPDX-License-Identifier: MPL-2.0
 	}
 </script>
 
-<div class="flex flex-col justify-center items-center w-screen h-1/6 p-4 -mt-10">
+<div class="flex flex-col justify-center items-center w-screen h-1/6 p-0 mb-2 -mt-12">
 	<div class="bg-white flex flex-col items-center justify-center rounded-3xl md:w-2/3 w-full" >
 		<div class="m-auto bg-white -mt-16 rounded-full p-3">
 			<CircularTimer
@@ -45,22 +45,13 @@ SPDX-License-Identifier: MPL-2.0
 				color="#ef4444"
 			/>
 		</div>
-		<h1 class="text-6xl mb-4 text-center text-[#00529B]">
+		<h1 class="text-6xl mb-0 text-center text-[#00529B]">
 			{@html quiz_data.questions[selected_question].question}
 		</h1>
 	</div>
-	<!--			<span class='text-center py-2 text-lg'>{$t('admin_page.time_left')}: {timer_res}</span>-->
-	<div class="grid grid-cols-3 my-2">
-		<span />
-		<span />
-		
-		<!-- <p class="m-auto text-lg border-2 px-4 py-2 rounded-xl border-[#0AEDFE] text-white">
-			{$t('admin_page.answers_submitted', { answer_count: answer_count })}
-		</p> -->
-	</div>
 </div>
 {#if quiz_data.questions[selected_question].image !== null}
-	<div class="flex justify-center w-full p-4">
+	<div class="flex justify-center w-full p-0">
 		<MediaComponent
 			src={quiz_data.questions[selected_question].image}
 			muted={false}
@@ -69,7 +60,7 @@ SPDX-License-Identifier: MPL-2.0
 	</div>
 {/if}
 {#if quiz_data.questions[selected_question].type === QuizQuestionType.ABCD || quiz_data.questions[selected_question].type === QuizQuestionType.VOTING || quiz_data.questions[selected_question].type === QuizQuestionType.CHECK}
-	<div class="grid grid-rows-2 grid-flow-col auto-cols-auto gap-2 w-full p-4">
+	<div class="grid grid-rows-2 grid-flow-col auto-cols-auto gap-2 w-full p-4 -mt-10">
 		{#each quiz_data.questions[selected_question].answers as answer, i}
 			<div
 				class="rounded-lg h-fit flex border-4 border-white"

--- a/frontend/src/lib/play/admin/question.svelte
+++ b/frontend/src/lib/play/admin/question.svelte
@@ -36,7 +36,7 @@ SPDX-License-Identifier: MPL-2.0
 	}
 </script>
 
-<div class="flex flex-col justify-center items-center w-screen h-1/6 p-4">
+<div class="flex flex-col justify-center items-center w-screen h-1/6 p-4 -mt-10">
 	<div class="bg-white flex flex-col items-center justify-center rounded-3xl md:w-2/3 w-full" >
 		<div class="m-auto bg-white -mt-16 rounded-full p-3">
 			<CircularTimer

--- a/frontend/src/lib/play/admin/results.svelte
+++ b/frontend/src/lib/play/admin/results.svelte
@@ -102,25 +102,25 @@ SPDX-License-Identifier: MPL-2.0
 		<div>
 			<table class="table-auto text-xl">
 				<tr>
-					<th class="p-2 border-r border-r-black border-b-2 border-b-black"
+					<th class="p-2 border-r border-r-white border-b-2 border-b-white text-white"
 						>{$t('words.name')}</th
 					>
-					<th class="p-2 border-b-2 border-b-black">{$t('words.point', { count: 2 })}</th>
+					<th class="p-2 border-b-2 border-b-white text-white">{$t('words.point', { count: 2 })}</th>
 					{#if show_new_score_clicked}
-						<th in:fly={{ x: 300 }} class="p-2 border-b-2 border-b-black"
+						<th in:fly={{ x: 300 }} class="p-2 border-b-2 border-b-white text-white"
 							>{$t('play_page.points_added')}
 						</th>
 					{/if}
 				</tr>
 				{#each player_names as player, i (player)}
 					<tr animate:flip>
-						<td class:hidden={i > 3} class="p-2 border-r border-r-black">{player}</td>
-						<td class:hidden={i > 3} class="p-2">{data[player]}</td>
+						<td class:hidden={i > 3} class="p-2 border-r border-r-white  text-white">{player}</td>
+						<td class:hidden={i > 3} class="p-2 text-white">{data[player]}</td>
 						{#if show_new_score_clicked}
 							<td
 								in:fly={{ x: 300 }}
 								class:hidden={i > 3}
-								class="p-2"
+								class="p-2 text-white"
 								class:text-red-600={score_by_username[player] === 0 ||
 									score_by_username[player] === undefined}
 							>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -72,18 +72,18 @@
 <CommandPalette />
 
 <style lang="scss">
-	:global(html.light){
-		background-image: url('$lib/assets/all/bg.webp');
+
+	:global(html.dark){
+		background-image: url('$lib/assets/all/bg_dark.webp') !important;
 		background-position: center;
 		background-repeat: no-repeat;
 		background-size: cover;
 	}
-	:global(html.dark){
-		background-image: url('$lib/assets/all/bg_dark.webp') !important;
-	}
 	:global(html:not(.dark)) {
-		background-color: #f3f7f9;
-		color: black;
+		background-image: url('$lib/assets/all/bg.webp');
+		background-position: center;
+		background-repeat: no-repeat;
+		background-size: cover;
 	}
 
 	:global(html.dark) {

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -119,11 +119,13 @@ SPDX-License-Identifier: MPL-2.0
 		</svg>
 	{:then quizzes}
 		<div class="flex flex-col w-full mx-auto">
-			<div class="w-full grid lg:grid-cols-4 gap-2 grid-cols-2 px-4">
-				<BrownButton href="/create">{$t('words.create')}</BrownButton>
-				<BrownButton href="/import">{$t('words.import')}</BrownButton>
-				<BrownButton href="/results">{$t('words.results')}</BrownButton>
-				<div class="flex gap-2">
+			<div class="w-full grid lg:grid-cols-2 gap-2 grid-cols-1 px-4">
+				<div class="flex gap-2 justify-content-around  w-full">
+					<BrownButton href="/create">{$t('words.create')}</BrownButton>
+					<BrownButton href="/import">{$t('words.import')}</BrownButton>
+				</div>
+				<div class="flex gap-2 justify-content-around  w-full">
+					<BrownButton href="/results">{$t('words.results')}</BrownButton>
 					<BrownButton href="/edit/files">{$t('words.files_library')}</BrownButton>
 					<BrownButton href="/account/settings">
 						{$t('words.settings')}
@@ -366,5 +368,6 @@ SPDX-License-Identifier: MPL-2.0
 <Footer />
 {#if start_game !== null}
 	<StartGamePopup bind:quiz_id={start_game} />
+
 {/if}
 <DownloadQuiz bind:quiz_id={download_id} />

--- a/frontend/src/routes/view/[quiz_id]/+page.svelte
+++ b/frontend/src/routes/view/[quiz_id]/+page.svelte
@@ -119,7 +119,7 @@
 	</p>
 	{#if quiz.cover_image}
 		<div class="flex justify-center align-middle items-center">
-			<div class=" m-auto w-4/5 my-3 p-4">
+			<div class=" m-auto w-4/5 my-3 p-4 flex justify-center">
 				{#if contentType?.startsWith('image')}
 					<img
 						class="max-h-full max-w-full block rounded-2xl"

--- a/frontend/src/routes/view/[quiz_id]/+page.svelte
+++ b/frontend/src/routes/view/[quiz_id]/+page.svelte
@@ -255,109 +255,117 @@
 			</div>
 		</div>
 	</div>
+	<div class="mb-5" >
+		{#if logged_in}
+			{#each quiz.questions as question, index_question}
+				<div class="px-4 py-1">
+					<CollapsSection headerText={question.question} expanded={auto_expand}>
+						<div class="grid grid-cols-1 gap-2 rounded-b-lg bg-white dark:bg-gray-700 -mt-1">
+							<h3 class="text-3xl m-1 text-center text-black dark:text-white">
+								{index_question + 1}: {@html question.question}
+							</h3>
 	
-	{#if logged_in}
-		{#each quiz.questions as question, index_question}
-			<div class="px-4 py-1">
-				<CollapsSection headerText={question.question} expanded={auto_expand}>
-					<div class="grid grid-cols-1 gap-2 rounded-b-lg bg-white dark:bg-gray-700 -mt-1">
-						<h3 class="text-3xl m-1 text-center text-black dark:text-white">
-							{index_question + 1}: {@html question.question}
-						</h3>
-
-						<!--					<label class='m-1 flex flex-row gap-2 w-3/5'>-->
-
-						<!--					</label>-->
-						{#if question.image}
-							<span class="flex justify-center">
-								<MediaComponent
-									css_classes="mx-auto"
-									src={question.image}
-									muted={false}
-								/>
-							</span>
-						{/if}
-						<p
-							class="m-1 flex flex-row gap-2 flex-nowrap whitespace-nowrap w-full justify-center text-gray-800 dark:text-gray-200"
-						>
-							<svg
-								class="w-8 h-8 inline-block"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-								xmlns="http://www.w3.org/2000/svg"
+							<!--					<label class='m-1 flex flex-row gap-2 w-3/5'>-->
+	
+							<!--					</label>-->
+							{#if question.image}
+								<span>
+									<MediaComponent
+										css_classes="mx-auto"
+										src={question.image}
+										muted={false}
+									/>
+								</span>
+							{/if}
+							<p
+								class="m-1 flex flex-row gap-2 flex-nowrap whitespace-nowrap w-full justify-center text-gray-800 dark:text-gray-200"
 							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-								/>
-							</svg>
-							<span class="text-lg">{question.time}s</span>
-						</p>
-						{#if question.type === QuizQuestionType.ABCD || question.type === undefined || question.type === QuizQuestionType.CHECK}
-							<div class="grid grid-cols-2 gap-4 m-4 p-6">
-								{#each question.answers as answer, index_answer}
-									<div
-										class="p-1 rounded-lg py-4 shadow-xl"
-										style="background-color: {answer.color ??
-											default_colors[index_answer]}; color: {get_foreground_color(
-											answer.color ?? default_colors[index_answer]
-										)}"
-										class:shadow-blue-500={answer.right &&
-											question.type !== QuizQuestionType.VOTING}
-										class:shadow-yellow-500={!answer.right &&
-											question.type !== QuizQuestionType.VOTING}
-									>
-										<h4 class="text-center">
-											{quiz.questions[index_question].answers[index_answer]
-												.answer}
-										</h4>
-									</div>
-								{/each}
-							</div>
-						{:else if question.type === QuizQuestionType.RANGE}
-							<p class="m-1 text-center text-gray-800 dark:text-gray-200">
-								All numbers between {question.answers.min_correct}
-								and {question.answers.max_correct} are correct, where numbers between {question
-									.answers.min} and {question.answers.max} can be selected.
+								<svg
+									class="w-8 h-8 inline-block"
+									fill="none"
+									stroke="currentColor"
+									viewBox="0 0 24 24"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+									/>
+								</svg>
+								<span class="text-lg">{question.time}s</span>
 							</p>
-						{:else if question.type === QuizQuestionType.ORDER}
-							<ul class="flex flex-col gap-4 m-4 p-6">
-								{#each question.answers as answer}
-									<li class="p-1 rounded-lg py-3 dark:bg-gray-500 bg-gray-300">
-										<h4 class="text-center text-black dark:text-white">
-											{answer.answer}
-										</h4>
-									</li>
-								{/each}
-							</ul>
-						{:else if question.type === QuizQuestionType.VOTING || question.type === QuizQuestionType.TEXT}
-							<div class="grid grid-cols-2 gap-4 m-4 p-6">
-								{#each question.answers as answer, index_answer}
-									<div class="p-1 rounded-lg py-4 dark:bg-gray-500 bg-gray-300">
-										<h4 class="text-center text-black dark:text-white">
-											{quiz.questions[index_question].answers[index_answer]
-												.answer}
-										</h4>
-									</div>
-								{/each}
-							</div>
-						{:else if question.type === QuizQuestionType.SLIDE}
-							{#await import('$lib/play/admin/slide.svelte')}
-								<Spinner my={false} />
-							{:then c}
-								<div class="max-h-[90%] max-w-[90%]">
-									<svelte:component this={c.default} bind:question />
+							{#if question.type === QuizQuestionType.ABCD || question.type === undefined || question.type === QuizQuestionType.CHECK}
+								<div class="grid grid-cols-2 gap-4 m-4 p-6">
+									{#each question.answers as answer, index_answer}
+										<div
+											class="p-1 rounded-lg py-4 shadow-xl"
+											style="background-color: {answer.color ??
+												default_colors[index_answer]}; color: {get_foreground_color(
+												answer.color ?? default_colors[index_answer]
+											)}"
+											class:shadow-blue-500={answer.right &&
+												question.type !== QuizQuestionType.VOTING}
+											class:shadow-yellow-500={!answer.right &&
+												question.type !== QuizQuestionType.VOTING}
+										>
+											<h4 class="text-center text-white">
+												{quiz.questions[index_question].answers[index_answer]
+													.answer}
+											</h4>
+										</div>
+									{/each}
 								</div>
-							{/await}
-						{/if}
-					</div>
-				</CollapsSection>
-			</div>
-		{/each}
-	{/if}
+							{:else if question.type === QuizQuestionType.RANGE}
+								<p class="m-1 text-center text-gray-800 dark:text-gray-200">
+									All numbers between {question.answers.min_correct}
+									and {question.answers.max_correct} are correct, where numbers between {question
+										.answers.min} and {question.answers.max} can be selected.
+								</p>
+							{:else if question.type === QuizQuestionType.ORDER}
+								<ul class="flex flex-col gap-4 m-4 p-6">
+									{#each question.answers as answer}
+										<li class="p-1 rounded-lg py-3 dark:bg-gray-500 bg-gray-300" style="background-color: {answer.color ??
+										default_colors[index_answer]}; color: {get_foreground_color(
+										answer.color ?? default_colors[index_answer]
+									)}">
+											<h4 class="text-center text-black dark:text-white">
+												{answer.answer}
+											</h4>
+										</li>
+									{/each}
+								</ul>
+							{:else if question.type === QuizQuestionType.VOTING || question.type === QuizQuestionType.TEXT}
+								<div class="grid grid-cols-2 gap-4 m-4 p-6">
+									{#each question.answers as answer, index_answer}
+										<div class="p-1 rounded-lg py-4 dark:bg-gray-500 bg-gray-300" 
+										style="background-color: {answer.color ??
+										default_colors[index_answer]}; color: {get_foreground_color(
+										answer.color ?? default_colors[index_answer]
+									)}">
+											<h4 class="text-center text-black dark:text-white">
+												{quiz.questions[index_question].answers[index_answer]
+													.answer}
+											</h4>
+										</div>
+									{/each}
+								</div>
+							{:else if question.type === QuizQuestionType.SLIDE}
+								{#await import('$lib/play/admin/slide.svelte')}
+									<Spinner my={false} />
+								{:then c}
+									<div class="max-h-[90%] max-w-[90%]">
+										<svelte:component this={c.default} bind:question />
+									</div>
+								{/await}
+							{/if}
+						</div>
+					</CollapsSection>
+				</div>
+			{/each}
+		{/if}
+	</div>
 </div>
 
 {#if start_game !== null}


### PR DESCRIPTION
This PR addresses the following issues based on #38, created by @AbhishekBante :
- The start game modal background did not cover the entire page, causing a jarring effect when scrolling.
- The colors for order-type question options were inconsistent with the updated color scheme.
- The QR code size was too small upon clicking.
- UI elements such as the red timer line and control components overlapped during question display.

**Modifications:**
- Set the start game modal to a `fixed` display to ensure full-page coverage.
- Updated default colors for order-type question options.
- Increased the QR code size for better visibility.
- Adjusted the display properties to prevent overlapping the red timer line and control components.

These changes minimize teachers' need for vertical scrolling, keeping controls accessible and improving the overall user experience.