### PR TITLE
Adjust layout to eliminate scrolling down if it is unnecessary

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -62,12 +62,17 @@
 <SvelteToast {options} />
 {#if $navbarVisible}
 	<Navbar />
-	<div class="pt-16 min-h-screen">
-		<div class="z-40" />
-		<slot />
+	<div class="pt-16 flex flex-col h-screen">
+		<div class="z-40 flex-1 overflow-y-auto">
+			<slot />
+		</div>
 	</div>
 {:else}
-	<slot />
+	<div class="flex flex-col h-screen">
+		<div class="flex-1 overflow-y-auto">
+			<slot />
+		</div>
+	</div>
 {/if}
 <CommandPalette />
 


### PR DESCRIPTION
The attempt in #42 was not enough to ensure the participant scrolling down was not enabled on the participant's mobile device. This PR is another attempt to modify the general layout.