### PR TITLE
Fix display answers per participant

### DIFF
--- a/classquiz/socket_server/__init__.py
+++ b/classquiz/socket_server/__init__.py
@@ -462,6 +462,7 @@ async def submit_answer(sid: str, data: dict):
         await redis.set(f"game:{session['game_pin']}", game_data.json())
         await sio.emit("everyone_answered", {})
 
+    await sio.emit("answer_acknowledged", room=sid)
 
 # await redis.set(f"game_data:{session['game_pin']}", json.dumps(data))
 

--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -70,9 +70,12 @@
 			question_index: question_index,
 			answer: cleanAnswer(answer)
 		});
-		toast.push(`You selected: ${cleanAnswer(answer)}`);
-		showPlayerAnswers = true;
+		toast.push(`You selected: ${cleanAnswer(selected_answer)}`);
 	};
+
+	socket.on('answer_acknowledged', () => {
+		showPlayerAnswers = true;
+	});
 
 	const selectRangeAnswer = (answer: string) => {
 		selected_answer = answer;
@@ -198,7 +201,7 @@
 			{/if}
 		</div>
 	{/if}
-	{#if timer_res !== '0'}
+	{#if timer_res !== '0' && !showPlayerAnswers}
 		{#if question.type === QuizQuestionType.ABCD || question.type === QuizQuestionType.VOTING}
 		<div class="flex flex-col justify-start items-start w-full p-4 mt-0 ${game_mode !== 'normal' ? ' h-4/5' : ''}">
 			<div class={`flex-grow relative w-full ${game_mode !== 'normal' ? 'h-full' : ''}`}>


### PR DESCRIPTION
This PR ensures that the display of answers is updated correctly for each participant. The `showPlayerAnswers` state now only affects the current player, preventing old submitted questions from appearing in the toast notifications.

#### Changes
- **Backend:** Emit `answer_acknowledged` event after submitting an answer.
- **Frontend:** Update `showPlayerAnswers` state upon receiving `answer_acknowledged` event.

**Note:** @AbhishekBante @Maria-CSV, we should test not only joining one participant but, if possible, joining more than one to detect this kind of bug.