### PR TITLE
Improve Disconnection Handling

### DIFF
--- a/classquiz/socket_server/__init__.py
+++ b/classquiz/socket_server/__init__.py
@@ -531,6 +531,17 @@ async def kick_player(sid: str, data: dict):
     )
     await sio.leave_room(player_sid, session["game_pin"])
     await sio.emit("kick", room=player_sid)
+    await sio.emit("disconnect_reason", {"reason": "You were kicked by the admin."}, room=player_sid)
+
+
+@sio.event
+async def disconnect(sid):
+    session = await sio.get_session(sid)
+    reason = "Connection lost."
+    if session.get('kicked', False):
+        reason = "You were kicked from the game."
+    
+    await sio.emit("disconnect_reason", {"reason": reason}, room=sid)
 
 
 class _RegisterAsRemoteInput(BaseModel):

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -21,6 +21,8 @@ SPDX-License-Identifier: MPL-2.0
 	const { t } = getLocalization();
 	import ZoniLogo from '$lib/components/zoniLogoPlay.svelte';
 
+	let disconnectedMessage = '';
+
 	// Exports
 	export let data;
 	let { game_pin } = data;
@@ -58,6 +60,13 @@ SPDX-License-Identifier: MPL-2.0
 	let preventReload = true;
 
 	// Functions
+	function handleDisconnection(reason: string) {
+    disconnectedMessage = reason;
+	if (browser) {
+			window.alert(`Disconnected: ${reason}`);
+		}
+	}
+
 	function restart() {
 		unique = {};
 	}
@@ -147,6 +156,23 @@ SPDX-License-Identifier: MPL-2.0
 		Cookies.set('kicked', 'value', { expires: 1 });
 		window.location.reload();
 	});
+
+	socket.on('connect_error', () => {
+		handleDisconnection('Connection error occurred.');
+	});
+
+	socket.on('reconnect_failed', () => {
+		handleDisconnection('Reconnection failed.');
+	});
+
+	socket.on('reconnect_attempt', () => {
+		handleDisconnection('Attempting to reconnect...');
+	});
+
+	socket.on('disconnect_reason', (data) => {
+  		handleDisconnection(data.reason);
+	});
+
 	socket.on('final_results', (data) => {
 		final_results = data;
 		Cookies.remove('joined_game');


### PR DESCRIPTION
- Added functionality to inform users about the reason for disconnection in both the client (`+page.svelte`) and server (`__init__.py`) components.
- Implemented new socket events for `connect_error`, `reconnect_failed`, and `disconnect_reason` to display appropriate messages to the user in the browser.
- Modified the `kick_player` event to emit a custom disconnect reason when a player is kicked from the game.

**Changes:**
- **`classquiz/socket_server/__init__.py`**:
  - Added new logic to handle user disconnection reasons and emit them via `disconnect_reason`.
  - Improved the `kick_player` function to notify the kicked player of the specific reason.

- **`frontend/src/routes/play/+page.svelte`**:
  - Implemented `handleDisconnection` function to manage and display disconnection reasons in the UI.
  - Added socket event listeners to handle connection errors, reconnection attempts, and display the appropriate alerts for users.
  - 