### PR TITLE
Enable NoSleep.js to Prevent Screen Lock During Activity Play

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"nosleep.js": "^0.12.0"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      nosleep.js:
+        specifier: ^0.12.0
+        version: 0.12.0
+
+packages:
+
+  nosleep.js@0.12.0:
+    resolution: {integrity: sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==}
+
+snapshots:
+
+  nosleep.js@0.12.0: {}


### PR DESCRIPTION
This PR introduces the integration of `NoSleep.js` to prevent the screen from locking during active activity. The `NoSleep` functionality is conditionally enabled in the browser environment, ensuring a seamless user experience by keeping the screen awake while the activity progresses. The changes include the following:

- **Activity play improvement**: 
  - Integrated `NoSleep.js` to keep the screen active during activity.
  - Added event listeners to enable `NoSleep` on the first user interaction.
  - Disabled `NoSleep` when the game ends, restoring normal screen behavior.

- **Browser-specific checks**: 
  - Wrapped `NoSleep.js` functionality in a `browser` check to ensure it only runs in the browser environment.

- **State management updates**:
  - Ensured that `NoSleep` is disabled when the final results are received, indicating the end of the activity.

**Files Changed:**
- `frontend/src/routes/play/+page.svelte`: 
  - Added `NoSleep.js` initialization and event handling logic to manage screen activity.
  
- `package.json`: 
  - Added `NoSleep.js` as a dependency.

- `pnpm-lock.yaml`: 
  - Updated to include the `NoSleep.js` package.

These changes improve the experience by preventing unwanted screen locking while ensuring proper state management throughout the activity session.

Note: If the user switches to another app or manually locks the screen, the application will stop. We have to implement more solutions to face this scenario.