### PR TITLE
Text color of your score block in light mode and height of no ans selected block

### DIFF
--- a/frontend/src/lib/play/admin/final_results.svelte
+++ b/frontend/src/lib/play/admin/final_results.svelte
@@ -49,7 +49,7 @@
 				<div class=" p-4 border-4 flex items-center border-[#00EDFF] rounded-lg shadow-lg bg-gradient-to-r from-[#0056BD] to-[#5436AB]">
 					<FinishingFlag />
 					<div class="w-2/3 m-auto" >
-						<p class="text-center text-lg font-medium text-[#00529B] dark:text-[#fff]">{$t('play_page.your_score', { score: data[username] })}</p>
+						<p class="text-center text-lg font-medium text-[#fff] dark:text-[#fff]">{$t('play_page.your_score', { score: data[username] })}</p>
 						{#each player_names as player, i}
 							{#if player === username}
 								<p class="text-center text-[#FFE500] text-xl font-semibold mt-2">{$t('play_page.your_place', { place: i + 1 })}</p>

--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -441,7 +441,7 @@
 			{/if}
 		{/if}
 		{:else if !showPlayerAnswers}
-			<div class="w-full flex justify-center min-h-screen items-center">
+			<div class={`w-full flex justify-center items-center ${game_mode === 'normal' ? 'h-full' : 'min-h-screen'}`}>
 				<h1 class="text-3xl dark:text-white text-[#0056BD] text-center p-3">{$t('admin_page.no_answers')}</h1>
 			</div>
 		{/if}


### PR DESCRIPTION
This PR implements:
1. Change text color of your score in light mode since it was blue which was making it invisible.
2. In mobile view and one device mode, if no option is selected, the participant needs to scroll to see the message, therefore added dynamic height class to this block.