### PR TITLE
Allow Late Join in Activity

### DIFF
--- a/classquiz/__init__.py
+++ b/classquiz/__init__.py
@@ -35,6 +35,7 @@ from classquiz.routers import (
     pixabay,
     moderation,
     session,
+    game_state
 )
 from classquiz.socket_server import sio
 from classquiz.helpers import meilisearch_init, telemetry_ping
@@ -108,4 +109,7 @@ app.include_router(community.router, tags=["community"], prefix="/api/v1/communi
 app.include_router(avatar.router, tags=["avatar"], prefix="/api/v1/avatar", include_in_schema=True)
 app.include_router(admin.router, tags=["admin"], prefix="/api/v1/admin", include_in_schema=True)
 app.include_router(session.router, tags=["session"], prefix="/api/v1/session", include_in_schema=True)
+
+app.include_router(game_state.router, tags=["game_state"], prefix="/api/v1/game_state", include_in_schema=True)
+
 app.mount("/", ASGIApp(sio))

--- a/classquiz/routers/game_state.py
+++ b/classquiz/routers/game_state.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, HTTPException
+from classquiz.config import redis
+from classquiz.db.models import PlayGame
+
+router = APIRouter()
+
+
+@router.get("/{game_pin}")
+async def fetch_game_state(game_pin: str):
+    data_redis_res = await redis.get(f"game:{game_pin}")
+    if data_redis_res is None:
+        raise HTTPException(status_code=404, detail="Game not found or API key not found")
+    
+    data = PlayGame.parse_raw(data_redis_res)
+    print(data)
+    return {
+        "game_pin": data.game_pin,
+        "started": data.started,
+        "current_question": data.current_question,
+        "questions_count": len(data.questions),
+        "title": data.title,
+        "description": data.description,
+        "cover_image": data.cover_image,
+        "background_color": data.background_color,
+        "background_image": data.background_image
+    }


### PR DESCRIPTION
This pull request introduces the ability for participants to join an ongoing activity after it has already started. Previously, new participants were unable to enter once the activity began. With this update, late joiners can seamlessly integrate into the activity, receive the current state, and participate in the remaining questions.

Key Changes:
- Updated `join_game` event handling in `socket_server` to allow late participants to join ongoing games.
- Added logic to broadcast the current game state (including the current question) to late joiners.
- Introduced new API endpoint `/api/v1/game_state/{game_pin}` to fetch the game state for rejoining participants.
- Enhanced the frontend Svelte component to handle late joins by fetching the game state and updating the UI accordingly.
- Persisted game state across sessions to allow reconnection and late join behavior.

Pending tasks (Not included on this PR):
- Displayed game information, including the PIN code, QR code, and URL, to inform late users how to join the activity.

Security Note:
Enhancing the security of the `/API/v1/game_state` endpoint to prevent unauthorized access is important. I think it's best that you implement appropriate authentication and validation checks to secure the game state retrieval in a future PR.