### PR TITLE
Fix issue of multiple answers by same user

### DIFF
--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -33,9 +33,10 @@
 	}
 
 	let timer_res = question.time;
-	let selected_answer: string | [];
+	let selected_answer: string | [] =  JSON.parse(localStorage.getItem("acknowledge"))?.answer || undefined;
 	let text_answer = [];
-	let showPlayerAnswers = false;
+	let acknowledgement = JSON.parse(localStorage.getItem("acknowledge"))?.answered;
+	let showPlayerAnswers = acknowledgement || false;
 
 	// Stop the timer if the question is answered
 	const timer = (time: string) => {
@@ -77,6 +78,11 @@
 	};
 
 	socket.on('answer_acknowledged', () => {
+		const val = JSON.stringify({
+			answered: true,
+			answer: selected_answer,
+		});
+		localStorage.setItem("acknowledge", val);
 		showPlayerAnswers = true;
 	});
 

--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -33,9 +33,9 @@
 	}
 
 	let timer_res = question.time;
-	let selected_answer: string | [] =  JSON.parse(localStorage.getItem("acknowledge"))?.answer || undefined;
+	let selected_answer: string | [] =  JSON.parse(localStorage.getItem("game_state"))?.acknowledge?.answer || undefined;
 	let text_answer = [];
-	let acknowledgement = JSON.parse(localStorage.getItem("acknowledge"))?.answered;
+	let acknowledgement = JSON.parse(localStorage.getItem("game_state"))?.acknowledge?.answered || false;
 	let showPlayerAnswers = acknowledgement || false;
 
 	// Stop the timer if the question is answered
@@ -78,11 +78,13 @@
 	};
 
 	socket.on('answer_acknowledged', () => {
-		const val = JSON.stringify({
+		const val = {
 			answered: true,
 			answer: selected_answer,
-		});
-		localStorage.setItem("acknowledge", val);
+		};
+		const storeState = JSON.parse(localStorage.getItem("game_state"));
+		storeState.acknowledge = val;
+		localStorage.setItem("game_state", JSON.stringify(storeState));
 		showPlayerAnswers = true;
 	});
 

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -76,7 +76,7 @@
 
 	// Functions for handling game state persistence using localStorage
 	function storeState() {
-		if (!username || !game_pin || !question_index) {
+		if (!username || !game_pin || !(question_index + 1)) {
 			return;
 		}
 		const state = {
@@ -211,6 +211,7 @@
 	socket.on('joined_game', (data) => {
 		gameData = data;
 		game_mode = data.game_mode;
+		localStorage.removeItem("acknowledge");
 		storeState();  // Save state after joining the game
 	});
 

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -79,6 +79,7 @@
 		if (!username || !game_pin || !(question_index + 1)) {
 			return;
 		}
+		const acknowledge = JSON.parse(localStorage.getItem('game_state'))?.acknowledge || {};
 		const state = {
 			game_pin,
 			username,
@@ -90,7 +91,8 @@
 			final_results,
 			game_mode,
 			question,
-			solution
+			solution,
+			acknowledge
 		};
 		localStorage.setItem('game_state', JSON.stringify(state));
 		console.log('State saved:', state);
@@ -248,6 +250,9 @@
 		question = data.question;
 		question_index = data.question_index;
 		answer_results = undefined;
+		const storeStates = JSON.parse(localStorage.getItem("game_state"));
+		delete storeStates.acknowledge;
+		localStorage.setItem("game_state", JSON.stringify(storeStates));
 		storeState();  // Save state when the question index changes
 	});
 


### PR DESCRIPTION
Issue: 
When a participant joins and quiz starts, player selects an answer then the answer is recorded but when user refreshes the page they get the same options again and therefore they can submit answer again even though they already answered the question.

Solution: 
Saved the answer selected and acknowledgment in local storage so if the same user joins again or refreshes the page it populates the selected answer and restrict player to not record their answer again.