### PR TITLE
After rejoining answer not submitting

### DIFF
--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -95,7 +95,7 @@
 			acknowledgement
 		};
 		localStorage.setItem('game_state', JSON.stringify(state));
-		console.log('State saved:', state);
+		// console.log('State saved:', state);
 	}
 
 	function restoreState() {
@@ -254,7 +254,7 @@
 		gameData = data;
 		if (data.started) {
 			gameMeta.started = true;
-			question_index = data.question_index;  // Set current question
+			question_index = data.current_question;  // Set current question
 		}
 		storeState();  // Store state after rejoining
 	});
@@ -339,7 +339,7 @@
 		}
 	});
 	$: language = gameData ? gameData.language_toggle : false;
-	$: console.log('Language:', language);
+	// $: console.log('Language:', language);
 	
 </script>
 


### PR DESCRIPTION
Problem: 
When participants refresh the page without submitting any answer, they can see the options after refresh but after selecting an answer, it's not being recorded in admin screen. And they can see the disabled options too.

Reason: 
When refreshed or rejoined the question index is undefined unbaling backend to record participant's response.

Solution: 
After debugging, found out that data getting after rejoin does not include the key "question_index", causing question_index variable to assign undefined. Instead of question_index key the backend is emitting "current_question" key, just replaced the same to solve the issue.