### PR TITLE
Fix player quiz joining

### DIFF
--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -20,7 +20,17 @@
 	// Exports
 	export let data;
 	let { game_pin } = data;
-
+	onMount(() => {
+		if (browser) {
+			const pin = JSON.parse(localStorage.getItem('game_state'));
+			
+			if (pin) {
+				game_pin = (pin.game_pin && pin.final_results[0] === null) ? pin.game_pin : '';
+			}else{
+				game_pin = '';
+			}
+		}
+	})
 	// Types
 	interface GameMeta {
 		started: boolean;
@@ -117,7 +127,6 @@
 			} = JSON.parse(savedState);
 
 			// Compare URL game_pin with stored game_pin
-			console.log('Compare Game Pin:', game_pin, storedGamePin);
 			if (game_pin !== storedGamePin) {
 				// If pins don't match, clear the state and allow the user to start a new session
 						clearState();
@@ -183,9 +192,11 @@
 	}
 
 	// Restore game state on load
-	if (browser) {
-		restoreState();
-	}
+	onMount(() => {
+		if (browser) {
+			restoreState();
+		}
+	})
 
 	const confirmUnload = () => {
 		if (preventReload) {


### PR DESCRIPTION
Issue: 
When the player refresh the page they see a form to enter activity code and username even though they did joined the game.

Expected Reason: 
This issue was in page.server.ts of play directory, it was fetching the game pin from params and returning to page.ts and since the params was empty the game_pin was empty too. And in restoreState function, it is first fetching game pin from local storage and compares it with the game_pin since the game_pin is empty, the function was clearing the localstorage and then player is needed to enter game pin again.

Solution:
Populated the game_pin onMount from localstorage.