### PR TITLE
Fix state loss on mobile by replacing `beforeunload` with `pagehide` and `visibilitychange`

### DIFF
--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import { onMount } from 'svelte';
 	import type { Question } from '$lib/quiz_types';
 	import { QuizQuestionType } from '$lib/quiz_types';
@@ -40,6 +41,12 @@
 	let acknowledgement;
 	let showPlayerAnswers = false;
 	let gameState: { acknowledgement?: { answered: boolean; answer: string } } = { acknowledgement: { answered: false, answer: '' } };
+
+	const dispatch = createEventDispatcher();
+
+	function triggerStoreState() {
+    	dispatch('storeStateNeeded');
+  	}
 
 	onMount(() => {
 		// Read gameState from localStorage once
@@ -114,6 +121,7 @@
 			answer: cleanAnswer(answer)
 		});
 		toast.push(`You selected: ${cleanAnswer(selected_answer)}`);
+		triggerStoreState();
 	};
 
 	socket.on('answer_acknowledged', () => {
@@ -121,9 +129,9 @@
 			answered: true,
 			answer: selected_answer,
 		};
-		gameState.acknowledgement = val; // Update cached gameState
-		localStorage.setItem("game_state", JSON.stringify(gameState)); // Write back to localStorage
+		gameState.acknowledgement = val;
   		showPlayerAnswers = true;
+		triggerStoreState();
 	});
 
 	const selectRangeAnswer = (answer: string) => {
@@ -134,6 +142,7 @@
 		});
 		toast.push(`You selected: ${answer}`);
 		showPlayerAnswers = true;
+		triggerStoreState();
 	};
 
 	const selectCheckAnswer = (answer: string, text_answer: []) => {
@@ -144,6 +153,7 @@
 		});
 		toast.push(`Your answer has been submitted!`);
 		showPlayerAnswers = true;
+		triggerStoreState();
 	};
 
 	const select_complex_answer = (data) => {
@@ -159,6 +169,7 @@
 		});
 		toast.push(`Your answer has been submitted!`);
 		showPlayerAnswers = true;
+		triggerStoreState();
 	};
 
 	let text_input = '';

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -206,13 +206,15 @@
 		}
 	}
 
-	const confirmUnload = () => {
-		if (preventReload) {
-			event.preventDefault();
-			event.returnValue = '';
-			storeState(); // Ensure state is saved before reload
-		}
-	};
+	function handlePageHide() {
+		storeState();
+	}
+
+	function handleVisibilityChange() {
+  		if (document.visibilityState === 'hidden') {
+    		storeState();
+  		}
+	}
 
 	// Socket events for managing the game connection and state
 	socket.on('time_sync', (data) => {
@@ -349,7 +351,7 @@
 	
 </script>
 
-<svelte:window on:beforeunload={confirmUnload} />
+<svelte:window on:pagehide={handlePageHide} on:visibilitychange={handleVisibilityChange} />
 <svelte:head>
 	<title>Zoni® AI - Play</title>
 </svelte:head>
@@ -377,7 +379,7 @@
 		{:else if gameMeta.started && gameData !== undefined && question_index !== '' && answer_results === undefined}
 			{#key unique}
 				<div class="text-[#00529B] dark:text-[#00529B]">
-					<Question bind:game_mode bind:question bind:question_index bind:solution bind:language />
+					<Question bind:game_mode bind:question bind:question_index bind:solution bind:language on:storeStateNeeded={storeState}/>
 				</div>
 			{/key}
 	


### PR DESCRIPTION
This PR fixes an issue where refreshing the page twice on mobile devices, particularly iOS devices, caused the game state to be lost, requiring users to re-enter their names. The problem was due to the unreliable firing of the `beforeunload` event on mobile Safari.

**Changes Made:**

- **Replaced `beforeunload` Event:**
  - Removed the `beforeunload` event listener in `+page.svelte`.
  - Added `pagehide` and `visibilitychange` event listeners to reliably detect when the page is being hidden or the visibility changes, ensuring `storeState()` is called appropriately.

- **Ensured `storeState()` is Called from `question.svelte`:**
  - In `question.svelte`, added a `createEventDispatcher` to dispatch a custom `storeStateNeeded` event whenever the state needs to be saved.
  - In `+page.svelte`, listened for the `storeStateNeeded` event from `Question` component and called `storeState()` when the event is dispatched.

**Files Modified:**

- `frontend/src/lib/play/question.svelte`: Added event dispatching to trigger state saving after user interactions.
- `frontend/src/routes/play/+page.svelte`: Replaced `beforeunload` with `pagehide` and `visibilitychange` events; updated to listen for the custom event from `question.svelte`.

**Impact:**

These changes improve the reliability of state preservation across page refreshes on mobile devices, enhancing the user experience by preventing unnecessary prompts to re-enter information. We will deploy it in production and check if the attempt to fix was successful.