### PR TITLE
Fix text translating even with english restrictions

### DIFF
--- a/frontend/src/lib/play/admin/final_results.svelte
+++ b/frontend/src/lib/play/admin/final_results.svelte
@@ -11,7 +11,7 @@
 	export let data;
 	export let username;
 	export let show_final_results: boolean;
-
+	export let language: boolean;
 	function sortObjectbyValue(obj) {
 		const ret = {};
 		Object.keys(obj)
@@ -49,10 +49,22 @@
 				<div class=" p-4 border-4 flex items-center border-[#00EDFF] rounded-lg shadow-lg bg-gradient-to-r from-[#0056BD] to-[#5436AB]">
 					<FinishingFlag />
 					<div class="w-2/3 m-auto" >
-						<p class="text-center text-lg font-medium text-[#fff] dark:text-[#fff]">{$t('play_page.your_score', { score: data[username] })}</p>
+						<p class="text-center text-lg font-medium text-[#fff] dark:text-[#fff]">
+							{#if language}
+								Your score: {data[username]}
+							{:else}
+								{$t('play_page.your_score', { score: data[username] })}
+							{/if}
+						</p>
 						{#each player_names as player, i}
 							{#if player === username}
-								<p class="text-center text-[#FFE500] text-xl font-semibold mt-2">{$t('play_page.your_place', { place: i + 1 })}</p>
+								<p class="text-center text-[#FFE500] text-xl font-semibold mt-2">
+									{#if language}
+									You're in position {i + 1 }!
+									{:else}
+										{$t('play_page.your_place', { place: i + 1 })}
+									{/if}
+								</p>
 							{/if}
 						{/each}
 					</div>

--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -326,7 +326,11 @@
 						on:click={() => selectRangeAnswer(slider_value[0])}
 						>
 							<RightArrow />
-							{$t('words.submit')}
+							{#if language}
+								{en.words.submit}
+							{:else}
+								{$t('words.submit')}
+							{/if}
 						</button>
 						<!-- <BrownButton
 							disabled={selected_answer !== undefined}
@@ -364,7 +368,11 @@
 				}}
 				>
 					<RightArrow />
-					{$t('words.submit')}
+					{#if language}
+						{en.words.submit}
+					{:else}
+						{$t('words.submit')}
+					{/if}
 				</button>
 				<!-- <BrownButton
 					type="button"
@@ -470,7 +478,12 @@
 						>
 						
 							<RightArrow />
-							{$t('words.submit')}
+							
+							{#if language}
+								{en.words.submit}
+							{:else}
+								{$t('words.submit')}
+							{/if}
 					</button>
 					<!-- <BrownButton
 						type="button"

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -365,7 +365,7 @@
 	
 		<!-- Show Final Results if the game has ended and results are available -->
 		{:else if JSON.stringify(final_results) !== JSON.stringify([null])}
-			<ShowEndScreen bind:data={scores} show_final_results={true} bind:username />
+			<ShowEndScreen bind:data={scores} bind:language show_final_results={true} bind:username />
 	
 		<!-- Show the Title if the game hasn't started yet and there's no question_index -->
 		{:else if !gameMeta.started && question_index === ''}


### PR DESCRIPTION
Issue:
There were some texts that were translating even though the English restriction was "on" for the particular quiz . Those were the submit buttons, and position information on final results screen.