### PR TITLE
Prevent Late Joiners from Submitting Answers After Solutions Are Shown

### DIFF
--- a/classquiz/routers/game_state.py
+++ b/classquiz/routers/game_state.py
@@ -22,5 +22,6 @@ async def fetch_game_state(game_pin: str):
         "description": data.description,
         "cover_image": data.cover_image,
         "background_color": data.background_color,
-        "background_image": data.background_image
+        "background_image": data.background_image,
+        "question_show": data.question_show
     }

--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -518,15 +518,25 @@
 	{#if showPlayerAnswers}
 	    <div class={`${game_mode !== 'normal' ? 'h-screen flex justify-center items-center' : ''}`}>
 			<div class="px-4 text-center">
-				<p class="text-lg font-semibold text-[#00529B] dark:text-[#fff] mt-10">Your answer:</p>
-				{#if Array.isArray(selected_answer)}
-				<ul class="list-disc list-inside mx-auto text-left text-[#00529B] inline-block dark:text-[#fff]">
-					{#each selected_answer as ans}
-					<li class="text-lg">{ans}</li>
-					{/each}
-				</ul>
+				{#if selected_answer !== undefined && selected_answer !== ''}	
+					<p class="text-lg font-semibold text-[#00529B] dark:text-[#fff] mt-10">Your answer:</p>
+					{#if Array.isArray(selected_answer)}
+					<ul class="list-disc list-inside mx-auto text-left text-[#00529B] inline-block dark:text-[#fff]">
+						{#each selected_answer as ans}
+						<li class="text-lg">{ans}</li>
+						{/each}
+					</ul>
+					{:else}
+					<p class="text-lg text-[#00529B] selected-ans bg-[#FFFFFF] font-bold p-4 rounded-lg mt-10">{selected_answer}</p>
+					{/if}
 				{:else}
-				<p class="text-lg text-[#00529B] selected-ans bg-[#FFFFFF] font-bold p-4 rounded-lg mt-10">{selected_answer}</p>
+					<p class="text-lg text-[#00529B] selected-ans bg-[#FFFFFF] font-bold p-4 rounded-lg mt-10">
+						{#if language}
+							{en.admin_page.no_answers}
+						{:else}
+							{$t('admin_page.no_answers')}
+						{/if}
+					</p>
 				{/if}
 			</div>
 		</div>

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -233,6 +233,11 @@
 						if (gameState.started) {
 							gameMeta.started = true;
 							question_index = gameState.question_index;
+							if (gameData.question_show === false) {
+        						acknowledgement.answered = true;
+        					} else {
+								acknowledgement.answered = false;
+							}
 						}
 					}
 				});
@@ -244,9 +249,14 @@
 	socket.on('joined_game', (data) => {
 		gameData = data;
 		game_mode = data.game_mode;
-		acknowledgement.answered = false;
-		acknowledgement.answer = '';
 		selected_answer = '';
+
+		if (data.question_show === false) {
+        	acknowledgement.answered = true;
+        } else {
+			acknowledgement.answered = false;
+		}
+
 		storeState();  // Save state after joining the game
 	});
 
@@ -257,6 +267,13 @@
 		gameData = data;
 		game_mode = data.game_mode;
 		gameMeta.started = true;  // Ensure the game state reflects that it's in progress
+
+		if (data.question_show === false) {
+        	acknowledgement.answered = true;
+        } else {
+			acknowledgement.answered = false;
+		}
+
 		storeState();  // Store the current game state locally
 	});
 
@@ -268,6 +285,13 @@
 			gameMeta.started = true;
 			question_index = data.current_question;  // Set current question
 		}
+
+		if (data.question_show === false) {
+        	acknowledgement.answered = true;
+        } else {
+			acknowledgement.answered = false;
+		}
+
 		storeState();  // Store state after rejoining
 	});
 
@@ -283,7 +307,11 @@
 		question = data.question;
 		question_index = data.question_index;
 		answer_results = undefined;
-		acknowledgement.answered = false;
+		if (data.question_show === false) {
+        	acknowledgement.answered = true;
+        } else {
+			acknowledgement.answered = false;
+		}
 		acknowledgement.answer = '';
 		selected_answer = '';
 		storeState();  // Save state when the question index changes


### PR DESCRIPTION
This PR fixes an issue where late joiners were able to submit answers even after the admin had revealed the solutions, which should not be allowed. The key changes include:

- **Game State Management**:
  - Updated the `question_show` flag to `false` when the admin selects "Show Solutions" or when time is up, ensuring that no further answers can be submitted.
  - Included the `question_show` state in the data sent to players during `join_game`, `rejoin_game`, and `set_question_number` events, so late joiners receive the correct game state.

- **Server-Side Updates** (`classquiz/socket_server/__init__.py`):
  - Modified the `show_solutions` event handler to set `question_show = False` and save the updated game data back to Redis.
  - Adjusted `submit_answer` to prevent answer submissions if time has expired, and set `question_show = False`.
  - Ensured that `question_show` is included in the data emitted to clients in relevant events.

- **Client-Side Adjustments**:
  - In the player's frontend (`frontend/src/routes/play/+page.svelte`), adjusted logic to respect the `question_show` flag, preventing answer submissions when solutions are already shown.
  - Improved UI feedback when no answer is available to display.
  - Ensured consistent state restoration and storage by including `acknowledgement.answered` based on `question_show`.