### PR TITLE
Prevent Joining Finalized Game Sessions

### DIFF
--- a/frontend/src/lib/play/join.svelte
+++ b/frontend/src/lib/play/join.svelte
@@ -53,6 +53,23 @@
 		}
 	});
 
+	async function fetchGameState(game_pin: string) {
+		try {
+		const response = await fetch(`/api/v1/game_state/${game_pin}`);
+		console.log('Fetch Game State Response:', response);
+
+		if (!response.ok) {
+			throw new Error(`Failed to fetch game state: ${response.statusText}`);
+		}
+
+		const gameState = await response.json();
+		return gameState;
+		} catch (error) {
+			console.error('Error fetching game state:', error);
+			return null;
+		}
+	}
+
 	const prefetch_username = async () => {
 		const res = await fetch('/api/v1/users/me');
 		if (res.status !== 200) {
@@ -64,7 +81,7 @@
 
 	const set_game_pin = async () => {
 		if (!game_pin) {
-			console.error('Game PIN is undefined or empty.');
+			console.error('PIN is undefined or empty.');
 			return;
 		}
 		let process_var;
@@ -73,6 +90,16 @@
 		} catch {
 			process_var = { env: { API_URL: undefined } };
 		}
+
+		fetchGameState(game_pin).then((gameState) => {
+			console.log('Game State:', gameState);
+			if (gameState) {
+				if ((gameState.current_question + 1 === gameState.questions_count) && !gameState.question_show) {
+				alert('This session has already ended.');
+				window.location.href = '/play';
+				}
+			}
+		});
 
 		const res = await fetch(
 			`${process_var.env.API_URL ?? ''}/api/v1/quiz/play/check_captcha/${game_pin}`

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -206,6 +206,15 @@
   		}
 	}
 
+	function checkFinalizedGame(gameData) {
+		if (gameData.current_question + 1 === gameData.question_count && gameData.question_show === false) {
+			gameEnded = true;
+			clearState();
+			alert('This session has already ended.');
+			window.location.href = '/play';
+		}
+	}
+
 	// Socket events for managing the game connection and state
 	socket.on('time_sync', (data) => {
 		socket.emit('echo_time_sync', data);
@@ -229,6 +238,7 @@
 				// Use the fetchGameState function to get the game state
 				fetchGameState(game_pin).then((gameState) => {
 					if (gameState) {
+						checkFinalizedGame(gameData);
 						gameData = gameState;
 						game_mode = gameState.game_mode;
 						if (gameState.started) {
@@ -264,6 +274,7 @@
 	socket.on('joined_game_late', (data) => {
 		// Handle receiving the current game state for late joiners
 		console.log('Joined late:', data);
+		checkFinalizedGame(data);
 
 		gameData = data;
 		game_mode = data.game_mode;

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -52,6 +52,7 @@
 		answer: '',
 	};
 	let selected_answer = '';
+	let gameEnded = false;
 
 	if (browser) {
     	restoreState();
@@ -101,7 +102,7 @@
 
 	// Functions for handling game state persistence using localStorage
 	function storeState() {
-		if (!username || !game_pin || question_index === null || question_index === undefined) {
+		if (!username || !game_pin || question_index === null || question_index === undefined || gameEnded) {
 			return;
 		}
 		const state = {
@@ -345,6 +346,7 @@
 
 	socket.on('final_results', (data) => {
 		final_results = data;
+		gameEnded = true;
 		clearState();  // Clear state when the game ends
 		if (browser) {
 			noSleep.disable(); // Disable wake lock when the game ends


### PR DESCRIPTION
These changes enhance the integrity of game sessions by preventing participants from joining activities that have already concluded.

- **Added `gameEnded` flag** to track when a game session has been finalized.
- **Implemented checks** in `join.svelte` and `+page.svelte` to verify if a game has ended before allowing a user to join.
- **Alert and redirect** users attempting to join an ended game to the main `/play` page, ensuring the game state is not stored post-finalization.