### PR TITLE
Fix for random issue allowing participants to answer after showing answers in Opera browser

### DIFF
--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -39,7 +39,6 @@
 	let timer_res = question.time;
 	let timer_interval; // Declare this outside to ensure there's only one interval running at a time
 	let text_answer = [];
-	let showPlayerAnswers = false;
 
 	const dispatch = createEventDispatcher();
 
@@ -56,8 +55,6 @@
 		// Read gameState from localStorage once
 		triggerRestoreState();
 
-		// Initialize variables from gameState
-    	showPlayerAnswers = acknowledgement.answered || false;
 		// Initialize and start timer based on `timer_res`
 		startTimer(timer_res, acknowledgement.answered);
 	});
@@ -121,7 +118,6 @@
 	socket.on('answer_acknowledged', () => {
 		acknowledgement.answered = true;
 		acknowledgement.selected_answer = selected_answer;
-  		showPlayerAnswers = true;
 		triggerStoreState();
 	});
 
@@ -132,7 +128,7 @@
 			answer: answer
 		});
 		toast.push(`You selected: ${answer}`);
-		showPlayerAnswers = true;
+		acknowledgement.answered = true;
 		triggerStoreState();
 	};
 
@@ -143,7 +139,7 @@
 			answer: answer,
 		});
 		toast.push(`Your answer has been submitted!`);
-		showPlayerAnswers = true;
+		acknowledgement.answered = true;
 		triggerStoreState();
 	};
 
@@ -159,7 +155,7 @@
 			complex_answer: new_array
 		});
 		toast.push(`Your answer has been submitted!`);
-		showPlayerAnswers = true;
+		acknowledgement.answered = true;
 		triggerStoreState();
 	};
 
@@ -253,7 +249,7 @@
 			{/if}
 		</div>
 	{/if}
-	{#if timer_res !== '0' && !showPlayerAnswers}
+	{#if timer_res !== '0' && !acknowledgement.answered}
 		{#if question.type === QuizQuestionType.ABCD || question.type === QuizQuestionType.VOTING}
 		<div class="flex flex-col justify-start items-start w-full p-4 mt-0 ${game_mode !== 'normal' ? ' h-4/5' : ''}">
 			<div class={`flex-grow relative w-full ${game_mode !== 'normal' ? 'h-full' : ''}`}>
@@ -486,7 +482,7 @@
 				</div>
 			</div>
 		{:else if question.type === QuizQuestionType.CHECK}
-			{#if !showPlayerAnswers}
+			{#if !acknowledgement.answered}
 				{#await import('./questions/check.svelte')}
 					<Spinner />
 				{:then c}
@@ -503,7 +499,7 @@
 				{/await}
 			{/if}
 		{/if}
-		{:else if !showPlayerAnswers}
+		{:else if !acknowledgement.answered}
 			<div class={`w-full flex justify-center items-center ${game_mode === 'normal' ? 'h-full' : 'min-h-screen'}`}>
 				<h1 class="text-3xl dark:text-white text-[#0056BD] text-center p-3">
 					{#if language}
@@ -515,7 +511,7 @@
 			</div>
 		{/if}
 	<!-- Display the submitted answer -->
-	{#if showPlayerAnswers}
+	{#if acknowledgement.answered}
 	    <div class={`${game_mode !== 'normal' ? 'h-screen flex justify-center items-center' : ''}`}>
 			<div class="px-4 text-center">
 				{#if selected_answer !== undefined && selected_answer !== ''}	

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -366,7 +366,10 @@
 
 	socket.on('solutions', (data) => {
 		solution = data;
+		acknowledgement.answered = true;
+		console.log('Acknowledgement before store:', acknowledgement);
 		storeState();
+		console.log('Acknowledgement after store:', acknowledgement);
 	});
 
 	let darkMode = false;


### PR DESCRIPTION
This PR resolves an issue where, in some instances using the Opera browser, participants were erroneously allowed to resubmit answers after their original response had already been acknowledged. 

Key changes include:
- Replacing instances of `showPlayerAnswers` with `acknowledgement.answered` for more reliable state handling.
- Updated conditional checks to ensure that once an answer is acknowledged, participants are prevented from resubmitting answers.

These improvements ensure a more consistent experience across all browsers, preventing accidental re-answers post-submission.