### PR TITLE
fix oversized width of options

### DIFF
--- a/frontend/src/lib/play/admin/question.svelte
+++ b/frontend/src/lib/play/admin/question.svelte
@@ -77,7 +77,7 @@ SPDX-License-Identifier: MPL-2.0
 		<div class="grid grid-rows-2 grid-flow-col auto-cols-auto gap-2 w-4/5 lg:w-full ps-1 ">
 			{#each quiz_data.questions[selected_question].answers as answer, i}
 				<div
-					class="rounded-lg h-full flex border-2 border-[#0056BD] items-center flex-grow lg:h-[20vh] lg:w-[48vw] lg:max-h-[20vh] lg:max-w-[48vw] w-[30vw] transition-all"
+					class="rounded-lg h-full flex border-2 border-[#0056BD] items-center flex-grow lg:min-h-[7vh] lg:min-w-full lg:max-h-[20vh] lg:max-w-[48vw] w-[30vw] transition-all"
 					style="background-color: {answer.color ?? default_colors[i]};"
 					class:opacity-50={!answer.right &&
 						timer_res === '0' &&


### PR DESCRIPTION
This PR fixes the size of options, if the text is small in options then the box should be normal as before, currently this box is too big even when the text is small.