### PR TITLE
Prevent re-submission of answers after page refresh by showing previously submitted answer

### DIFF
--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -292,18 +292,27 @@
 
 	socket.on('rejoined_game', (data) => {
 		console.log('Game rejoined successfully!');
+		console.log('Latest answer:', data.latest_answer);
 		gameData = data;
 		if (data.started) {
 			gameMeta.started = true;
 			question_index = data.current_question;  // Set current question
 		}
 
-		if (data.question_show === false) {
-        	acknowledgement.answered = true;
-        } else {
-			acknowledgement.answered = false;
+		if (data.latest_answer) {
+			if (data.latest_answer.question_index === question_index) {
+				acknowledgement.answered = true;
+				acknowledgement.answer = data.latest_answer.answer;
+			} else {
+				acknowledgement.answered = false;
+			}
+		} else {
+			if (data.question_show === false) {
+        		acknowledgement.answered = true;
+        	} else {
+				acknowledgement.answered = false;
+			}
 		}
-
 		storeState();  // Store state after rejoining
 	});
 


### PR DESCRIPTION
This PR addresses an issue where a player, who has already submitted an answer during an ongoing question, would see the option to select an answer again upon refreshing the page. This behavior is incorrect as the player has already answered the question, and reselecting would not be allowed while the question is still active.

**Problem Description:**
When a player submits an answer while there is still time left for others to respond, and then refreshes the page, the option to answer is displayed again. This is misleading, as the player has already submitted an answer. Ideally, when the player refreshes the page, their previous answer should be shown, and the option to select a new answer should not be displayed.

**Solution:**
1. Implemented a function `get_latest_submitted_answer` to fetch the player's last submitted answer from the server during the `rejoin_game` event.
2. Modified the `rejoin_game` event to emit the latest submitted answer along with the game state.
3. Updated the frontend to handle the `latest_answer` data and ensure that, if an answer has already been submitted for the current question, it is shown to the player. This prevents the option to reselect an answer after refreshing the page.
4. If no answer has been submitted, the question selection UI is displayed as expected.