### PR TITLE
Fix inconsistent ranking for late joined participant

### DIFF
--- a/classquiz/socket_server/__init__.py
+++ b/classquiz/socket_server/__init__.py
@@ -220,7 +220,7 @@ async def join_game(sid: str, data: dict):
     if game_data.started:
         # Allow late join but emit a warning or set conditions for the player
         await sio.emit("game_already_started_but_allowed", room=sid)
-
+        player_scores = await redis.hgetall(f"game_session:{data.game_pin}:player_scores")
         # Emit current game state and question to late joiners
         print("Joining game late")
         await sio.emit(
@@ -230,6 +230,7 @@ async def join_game(sid: str, data: dict):
                 "current_question": game_data.current_question,
                 "question_count": len(game_data.questions),
                 "question_show": game_data.question_show,
+                "player_scores": player_scores
             },
             room=sid,
         )

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -275,7 +275,10 @@
 		// Handle receiving the current game state for late joiners
 		console.log('Joined late:', data);
 		checkFinalizedGame(data);
-
+		let converted_scores =  Object.fromEntries(Object.entries(data.player_scores).map(([key, value]) => [key, Number(value)])); // This statement converts string values to numbers in an object
+		scores = converted_scores;
+		console.log('scores', scores);
+		
 		gameData = data;
 		game_mode = data.game_mode;
 		gameMeta.started = true;  // Ensure the game state reflects that it's in progress


### PR DESCRIPTION
Issue:
When a participant joins the activity late, the final result at the end of the activity is different from the admin screen for the late participant.
In this case, when the participant is joining the activity, the scores are considered only after they joined (it's only for the individual) and previous scores of other participants are not added. Therefore, it led to inconsistent scores.

Solution:
Returned all scores of other users when a participant joins late, and assigned populated the scores from storeState to the fetched scores.
