### PR TITLE
Added feature to add images as options while creating activity

### DIFF
--- a/classquiz/db/models.py
+++ b/classquiz/db/models.py
@@ -136,6 +136,7 @@ class QuizQuestion(BaseModel):
     type: None | QuizQuestionType = QuizQuestionType.ABCD
     answers: list[ABCDQuizAnswer] | RangeQuizAnswer | list[TextQuizAnswer] | list[VotingQuizAnswer] | str
     image: str | None = None
+    ansType: str | None = None
 
     @validator("answers")
     def answers_not_none_if_abcd_type(cls, v, values):

--- a/frontend/src/lib/editor/ABCDEditorPart.svelte
+++ b/frontend/src/lib/editor/ABCDEditorPart.svelte
@@ -13,6 +13,8 @@ SPDX-License-Identifier: MPL-2.0
 	import { getLocalization } from '$lib/i18n';
 	import { get_foreground_color } from '$lib/helpers';
 	import { toast } from '@zerodevx/svelte-toast';
+	import Spinner from '$lib/Spinner.svelte';
+	import MediaComponent from './MediaComponent.svelte';
 
 	const { t } = getLocalization();
 
@@ -21,6 +23,9 @@ SPDX-License-Identifier: MPL-2.0
 	export let selected_question: number;
 	export let check_choice = false;
 	export let data: EditorData;
+	export let edit_id;
+	let optionsType;
+	let uppyOpen = false;
 	if (!Array.isArray(data.questions[selected_question].answers)) {
 		data.questions[selected_question].answers = [];
 	}
@@ -70,6 +75,8 @@ SPDX-License-Identifier: MPL-2.0
 			console.log("Under 100");
 		}
 	}
+
+	$: optionsType = data.questions[selected_question].ansType;
 </script>
 
 <div class="grid grid-rows-2 grid-flow-col auto-cols-auto gap-4 w-full px-10">
@@ -108,6 +115,7 @@ SPDX-License-Identifier: MPL-2.0
 						/>
 					</svg>
 				</button>
+				{#if optionsType === 'TEXT'}
 				<input
 					bind:value={answer.answer}
 					type="text"
@@ -119,6 +127,53 @@ SPDX-License-Identifier: MPL-2.0
 					on:input={() => handleTextChange(selected_question,index)}
 					placeholder={$t('editor.enter_answer')}
 				/>
+				{:else}
+					{#if answer.answer}
+						<div class="flex justify-center pt-10 w-full h-72">
+							<MediaComponent bind:src={answer.answer} />
+							<div class="h-72 relative">
+								<button
+									class="rounded-full absolute -top-2 -right-2 opacity-70 hover:opacity-100 transition"
+									type="button"
+									on:click={() => {
+										answer.answer = "";
+									}}
+								>
+									<svg
+										class="w-6 h-6 bg-red-500 rounded-full"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+										xmlns="http://www.w3.org/2000/svg"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+										/>
+									</svg>
+								</button>
+							</div>
+							
+						</div>
+					{:else}
+						{#await import('$lib/editor/uploader.svelte')}
+							<Spinner my_20={false} />
+						{:then c}
+							<svelte:component
+								this={c.default}
+								bind:modalOpen={uppyOpen}
+								bind:edit_id
+								other_upload={false}
+								selected_answer={index}
+								bind:data
+								bind:selected_question
+								video_upload={false}
+							/>
+						{/await}
+					{/if}
+				{/if}
 				<button
 					type="button"
 					on:click={() => {
@@ -168,7 +223,38 @@ SPDX-License-Identifier: MPL-2.0
 			</div>
 		{/each}
 	{/if}
-	{#if data.questions[selected_question].answers.length < 4}
+	{#if data.questions[selected_question].answers.length === 0}
+		<button
+			class="p-4 rounded-lg bg-transparent border-gray-500 border-2 hover:bg-gray-300 transition dark:hover:bg-gray-600"
+			type="button"
+			in:fade|local={{ duration: 150 }}
+			on:click={() => {
+				data.questions[selected_question].answers = [
+					...data.questions[selected_question].answers,
+					{ ...get_empty_answer(data.questions[selected_question].answers.length) }
+				];
+				data.questions[selected_question].ansType = "TEXT";
+			}}
+		>
+			<span class="italic text-center">Add Text Options</span>
+		</button>
+		<button
+			class="p-4 rounded-lg bg-transparent border-gray-500 border-2 hover:bg-gray-300 transition dark:hover:bg-gray-600"
+			type="button"
+			in:fade|local={{ duration: 150 }}
+			on:click={() => {
+				data.questions[selected_question].answers = [
+					...data.questions[selected_question].answers,
+					{ ...get_empty_answer(data.questions[selected_question].answers.length) }
+				];
+				data.questions[selected_question].ansType = "IMAGE";
+			}}
+		>
+			<span class="italic text-center">Add Image Options</span>
+		</button>
+	{/if}
+
+	{#if data.questions[selected_question].answers.length < 4 && data.questions[selected_question].answers.length > 0}
 		<button
 			class="p-4 rounded-lg bg-transparent border-gray-500 border-2 hover:bg-gray-300 transition dark:hover:bg-gray-600"
 			type="button"

--- a/frontend/src/lib/editor/ABCDEditorPart.svelte
+++ b/frontend/src/lib/editor/ABCDEditorPart.svelte
@@ -167,6 +167,7 @@ SPDX-License-Identifier: MPL-2.0
 								bind:edit_id
 								other_upload={false}
 								selected_answer={index}
+								option_upload={true}
 								bind:data
 								bind:selected_question
 								video_upload={false}

--- a/frontend/src/lib/editor/VotingEditorPart.svelte
+++ b/frontend/src/lib/editor/VotingEditorPart.svelte
@@ -12,12 +12,17 @@ SPDX-License-Identifier: MPL-2.0
 	import { VotingQuestionSchema } from '$lib/yupSchemas';
 	import { get_foreground_color } from '$lib/helpers';
 	import { toast } from '@zerodevx/svelte-toast';
+	import Spinner from '$lib/Spinner.svelte';
+	import MediaComponent from './MediaComponent.svelte';
 
 	const { t } = getLocalization();
 
 	const default_colors = ['#FFA800', '#00A3FF', '#FF1D38', '#00D749'];
 	export let selected_question: number;
 	export let data: EditorData;
+	export let edit_id;
+	let optionsType;
+	let uppyOpen = false;
 
 	if (!Array.isArray(data.questions[selected_question].answers)) {
 		data.questions[selected_question].answers = [];
@@ -55,6 +60,7 @@ SPDX-License-Identifier: MPL-2.0
             data.questions[selected_question].answers[i].right = undefined;
         }
     });*/
+	$: optionsType = data.questions[selected_question].ansType;
 </script>
 
 <div class="grid grid-rows-2 grid-flow-col auto-cols-auto gap-4 w-full px-10">
@@ -93,6 +99,7 @@ SPDX-License-Identifier: MPL-2.0
 						/>
 					</svg>
 				</button>
+				{#if optionsType === 'TEXT'}
 				<input
 					bind:value={answer.answer}
 					type="text"
@@ -103,6 +110,52 @@ SPDX-License-Identifier: MPL-2.0
 					on:input={() => handleTextChange(selected_question,index)}
 					placeholder={$t('editor.empty')}
 				/>
+				{:else}
+					{#if answer.answer}
+						<div class="flex justify-center pt-10 w-full h-72">
+							<MediaComponent bind:src={answer.answer} />
+							<div class="h-72 relative">
+								<button
+									class="rounded-full absolute -top-2 -right-2 opacity-70 hover:opacity-100 transition"
+									type="button"
+									on:click={() => {
+										answer.answer = "";
+									}}
+								>
+									<svg
+										class="w-6 h-6 bg-red-500 rounded-full"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+										xmlns="http://www.w3.org/2000/svg"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+										/>
+									</svg>
+								</button>
+							</div>
+							
+						</div>
+					{:else}
+						{#await import('$lib/editor/uploader.svelte')}
+							<Spinner my_20={false} />
+						{:then c}
+							<svelte:component
+								this={c.default}
+								bind:modalOpen={uppyOpen}
+								bind:edit_id
+								selected_answer={index}
+								bind:data
+								bind:selected_question
+								video_upload={true}
+							/>
+						{/await}
+					{/if}
+				{/if}
 				<input
 					class="rounded-lg p-1 border-black border"
 					type="color"
@@ -114,7 +167,50 @@ SPDX-License-Identifier: MPL-2.0
 			</div>
 		{/each}
 	{/if}
-	{#if data.questions[selected_question].answers.length < 4}
+	{#if data.questions[selected_question].answers.length === 0}
+		<button
+		class="p-4 rounded-lg bg-transparent border-gray-500 border-2 hover:bg-gray-300 transition dark:hover:bg-gray-600"
+		type="button"
+		in:fade|local={{ duration: 150 }}
+		on:click={() => {
+			data.questions[selected_question].answers = [
+				...data.questions[selected_question].answers,
+				{
+					...{
+						answer: '',
+						image: undefined,
+						color: default_colors[data.questions[selected_question].answers.length]
+					}
+				}
+			];
+			data.questions[selected_question].ansType = "TEXT";
+		}}
+		>
+			<span class="italic text-center">Add Text Options</span>
+		</button>
+		<button
+		class="p-4 rounded-lg bg-transparent border-gray-500 border-2 hover:bg-gray-300 transition dark:hover:bg-gray-600"
+		type="button"
+		in:fade|local={{ duration: 150 }}
+		on:click={() => {
+			data.questions[selected_question].answers = [
+				...data.questions[selected_question].answers,
+				{
+					...{
+						answer: '',
+						image: undefined,
+						color: default_colors[data.questions[selected_question].answers.length]
+					}
+				}
+			];
+			data.questions[selected_question].ansType = "IMAGE";
+		}}
+		>
+			<span class="italic text-center">Add Image Options</span>
+		</button>
+	{/if}
+
+	{#if data.questions[selected_question].answers.length < 4 && data.questions[selected_question].answers.length > 0}
 		<button
 			class="p-4 rounded-lg bg-transparent border-gray-500 border-2 hover:bg-gray-300 transition dark:hover:bg-gray-600"
 			type="button"

--- a/frontend/src/lib/editor/card.svelte
+++ b/frontend/src/lib/editor/card.svelte
@@ -57,8 +57,9 @@ SPDX-License-Identifier: MPL-2.0
 	const update_image_url = () => {
 		image_url = data.questions[selected_question].image;
 	};
+	
 	$: {
-		update_image_url();
+		update_image_url();		
 		selected_question;
 		data.questions;
 	}
@@ -205,6 +206,7 @@ SPDX-License-Identifier: MPL-2.0
 								this={c.default}
 								bind:data
 								bind:selected_question
+								bind:edit_id
 								check_choice={type === QuizQuestionType.CHECK}
 							/>
 						{/await}

--- a/frontend/src/lib/editor/uploader.svelte
+++ b/frontend/src/lib/editor/uploader.svelte
@@ -26,6 +26,7 @@ SPDX-License-Identifier: MPL-2.0
 	import { onMount } from 'svelte';
 	import Library from '$lib/editor/uploader/Library.svelte';
 	import Pixabay from '$lib/editor/uploader/Pixabay.svelte';
+	import { toast } from '@zerodevx/svelte-toast';
 
 	const { t } = getLocalization();
 
@@ -35,6 +36,7 @@ SPDX-License-Identifier: MPL-2.0
 	export let selected_question: number;
 	export let video_upload = false;
 	export let other_upload = false;
+	export let option_upload = false;
 	export let library_enabled = true;
 	export let selected_answer = -1;
 
@@ -92,6 +94,16 @@ SPDX-License-Identifier: MPL-2.0
 
 	let image_id;
 	let audio_id;
+	uppy.on('file-added', (file) => {
+		if(option_upload){
+			console.log("Inside file-added", file);
+			
+			if (file.extension !== 'webp') {
+				uppy.removeFile(file.id,"removed-by-user");
+				toast.push(`Unsupported file type ${file.extension} for ${file.name}`);
+			} 
+		}
+	});
 
 	uppy.on('upload-success', (file, response) => {
 		if (selected_type === AvailableUploadTypes.Image) {

--- a/frontend/src/lib/editor/uploader.svelte
+++ b/frontend/src/lib/editor/uploader.svelte
@@ -34,7 +34,9 @@ SPDX-License-Identifier: MPL-2.0
 	export let data: EditorData;
 	export let selected_question: number;
 	export let video_upload = false;
+	export let other_upload = false;
 	export let library_enabled = true;
+	export let selected_answer = -1;
 
 	// eslint-disable-next-line no-undef
 	let video_popup: undefined | WindowProxy = undefined;
@@ -110,16 +112,25 @@ SPDX-License-Identifier: MPL-2.0
 				data.background_audio = audio_id;
 			}
 		} else {
-			if (selected_type === AvailableUploadTypes.Image) {
-                if (!data.questions[selected_question]) {
-                    data.questions[selected_question] = {};
-                }
-				data.questions[selected_question].image = image_id;
-			} else if (selected_type === AvailableUploadTypes.Audio) {
-                if (!data.questions[selected_question]) {
-                    data.questions[selected_question] = {};
-                }
-				data.questions[selected_question].image = audio_id;
+			if(selected_answer === -1) {
+				if (selected_type === AvailableUploadTypes.Image) {
+					if (!data.questions[selected_question]) {
+						data.questions[selected_question] = {};
+					}
+					data.questions[selected_question].image = image_id;
+				} else if (selected_type === AvailableUploadTypes.Audio) {
+					if (!data.questions[selected_question]) {
+						data.questions[selected_question] = {};
+					}
+					data.questions[selected_question].image = audio_id;
+				}
+			}else if(selected_answer !== -1) {
+				if (selected_type === AvailableUploadTypes.Image) {
+					if (!data.questions[selected_question]) {
+						data.questions[selected_question] = {};
+					}
+					data.questions[selected_question].answers[selected_answer].answer = image_id;
+				}
 			}
 		}
 
@@ -200,6 +211,7 @@ SPDX-License-Identifier: MPL-2.0
 					{#if library_enabled}
 						<div class="w-full">
 							<BrownButton
+								disabled={!other_upload}
 								on:click={() => {
 									selected_type = AvailableUploadTypes.Library;
 								}}
@@ -209,6 +221,7 @@ SPDX-License-Identifier: MPL-2.0
 					{/if}
 					<div class="w-full">
 						<BrownButton
+							disabled={!other_upload}
 							on:click={() => {
 								selected_type = AvailableUploadTypes.Pixabay;
 							}}

--- a/frontend/src/lib/play/admin/question.svelte
+++ b/frontend/src/lib/play/admin/question.svelte
@@ -77,13 +77,14 @@ SPDX-License-Identifier: MPL-2.0
 	{#if quiz_data.questions[selected_question].type === QuizQuestionType.ABCD || quiz_data.questions[selected_question].type === QuizQuestionType.VOTING || quiz_data.questions[selected_question].type === QuizQuestionType.CHECK}
 		<div class="grid grid-rows-2 grid-flow-col auto-cols-auto gap-2 w-4/5 lg:w-full ps-1 ">
 			{#each quiz_data.questions[selected_question].answers as answer, i}
-				<div
-					class="rounded-lg h-full flex border-2 border-[#0056BD] items-center flex-grow lg:min-h-[7vh] lg:min-w-full lg:max-h-[20vh] lg:max-w-[48vw] w-[30vw] transition-all"
-					style="background-color: {answer.color ?? default_colors[i]};"
-					class:opacity-50={!answer.right &&
+			<div
+			class="rounded-lg h-full flex border-2 border-[#0056BD] items-center p-2 flex-grow lg:min-h-[7vh] lg:min-w-full lg:max-h-[20vh] lg:max-w-[48vw] w-[30vw] transition-all" class:justify-center={quiz_data.questions[selected_question].ansType === "IMAGE"}
+			style="background-color: {answer.color ?? default_colors[i]};"
+			class:opacity-50={!answer.right &&
 						timer_res === '0' &&
 						quiz_data.questions[selected_question].type === QuizQuestionType.ABCD}
 				>
+				{#if quiz_data.questions[selected_question].ansType === "TEXT" || quiz_data.questions[selected_question].ansType === null}
 					<p class="md:text-7xl text-4xl font-bold text-[#fff] ps-1">
 						{optionsLabel[i]}
 					</p>
@@ -91,7 +92,11 @@ SPDX-License-Identifier: MPL-2.0
 						class="text-center fluid-text-md lg:text-2xl break-all md:text-xl sm:text-lg px-2 overflow-auto py-2 w-full text-[#fff] "
 						>{answer.answer}</p
 					>
+				{:else}
+					<MediaComponent css_classes="w-fit m-2 h-full" bind:src={answer.answer} />
+				{/if}
 				</div>
+				
 			{/each}
 		</div>
 	{:else if quiz_data.questions[selected_question].type === QuizQuestionType.TEXT}

--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -17,7 +17,7 @@
 	import en from '$lib/i18n/locales/en.json';
 
 	const { t } = getLocalization();
-
+	const default_options = ['A', 'B', 'C', 'D'];
 	export let question: Question;
 	export let game_mode;
 	export let question_index: string | number;
@@ -25,7 +25,7 @@
 	export let language;
 	export let selected_answer;
 	export let acknowledgement;
-
+	let ans_index = -1;
 	$: console.log(question_index, question, 'hi!');
 
 	console.log(question);
@@ -105,13 +105,18 @@
 		return answer.trim().replace(/\s+/g, ' ');
 	};
 
-	const selectAnswer = (answer: string) => {
+	const selectAnswer = (answer: string, i:number = 0) => {
 		selected_answer = answer;
+		ans_index = question.ansType === 'TEXT' || question.ansType === null ? -1 : i;
 		socket.emit('submit_answer', {
 			question_index: question_index,
 			answer: cleanAnswer(answer)
 		});
-		toast.push(`You selected: ${cleanAnswer(selected_answer)}`);
+		if(question.ansType === 'TEXT' || question.ansType === null){
+			toast.push(`You selected: ${cleanAnswer(selected_answer)}`);
+		}else{
+			toast.push(`You selected: ${default_options[i]}`);
+		}
 		triggerStoreState();
 	};
 
@@ -134,6 +139,7 @@
 
 	const selectCheckAnswer = (answer: string, text_answer: []) => {
 		selected_answer = text_answer;
+		ans_index = question.ansType === 'TEXT' || question.ansType === null ? -1 : 1;
 		socket.emit('submit_answer', {
 			question_index: question_index,
 			answer: answer,
@@ -272,7 +278,7 @@
 							class="rounded-lg h-full  flex items-center justify-center disabled:opacity-60 border-4 border-white transition-all my-2"
 							style="background-color: {answer.color ?? default_colors[i]}; color: {get_foreground_color(answer.color ?? default_colors[i])}"
 							disabled={selected_answer !== ''}
-							on:click={() => selectAnswer(answer.answer)}
+							on:click={() => selectAnswer(answer.answer,i)}
 						>
 							{#if game_mode === 'kahoot'}
 								<img class="inline-block m-auto max-h-[30vh]" alt="Icon" src={kahoot_icons[i]} />
@@ -519,11 +525,19 @@
 					{#if Array.isArray(selected_answer)}
 					<ul class="list-disc list-inside mx-auto text-left text-[#00529B] inline-block dark:text-[#fff]">
 						{#each selected_answer as ans}
+						{#if ans_index === -1}
 						<li class="text-lg">{ans}</li>
+						{:else}
+							<li class="text-lg">{default_options[question.answers.findIndex((a) => a.answer === ans)]}</li>
+						{/if}
 						{/each}
 					</ul>
 					{:else}
-					<p class="text-lg text-[#00529B] selected-ans bg-[#FFFFFF] font-bold p-4 rounded-lg mt-10">{selected_answer}</p>
+						{#if ans_index !== -1}
+						<p class="text-lg text-[#00529B] selected-ans bg-[#FFFFFF] font-bold p-4 rounded-lg mt-10">{default_options[ans_index]}</p>
+						{:else}
+							<p class="text-lg text-[#00529B] selected-ans bg-[#FFFFFF] font-bold p-4 rounded-lg mt-10">{selected_answer}</p>
+						{/if}
 					{/if}
 				{:else}
 					<p class="text-lg text-[#00529B] selected-ans bg-[#FFFFFF] font-bold p-4 rounded-lg mt-10">

--- a/frontend/src/lib/quiz_types.ts
+++ b/frontend/src/lib/quiz_types.ts
@@ -62,6 +62,7 @@ export interface Question {
 	type?: QuizQuestionType;
 	image?: string;
 	answers: Answers;
+	ansType: "TEXT" | "IMAGE";
 }
 
 export type Answers =


### PR DESCRIPTION
This PR adds following feature:

While creating quiz, added an option to add image or text as answers of questions with type check, ABCD and voting.
Ensured that if the answer type is Image then in admin screen the option should show images instead of text.

Added a property in models, there's no need to migrate anything since we are not changing any database schema.