### PR TITLE
Add failback when KeyError: 'ping' is not defined to calculate latency

### DIFF
--- a/classquiz/socket_server/__init__.py
+++ b/classquiz/socket_server/__init__.py
@@ -567,7 +567,8 @@ async def submit_answer(sid: str, data: dict):
         answer_right = bool(correct_string == data.answer)
     else:
         raise NotImplementedError
-    latency = int(float((await sio.get_session(sid))["ping"]))
+    session = await sio.get_session(sid)
+    latency = int(float(session.get("ping", 0)))  # use 0 if ping is not set
     time_q_started = datetime.fromisoformat(await redis.get(f"game:{session['game_pin']}:current_time"))
 
     diff = (time_q_started - now).total_seconds() * 1000  # - timedelta(milliseconds=latency)


### PR DESCRIPTION
During local development for some reason the Socket Server is generating the below error:

```
/home/oscar/.local/share/virtualenvs/games-vv6Brqdh/lib/python3.11/site-packages/socketio/async_server.py:605> exception=KeyError('ping')>
Traceback (most recent call last):
  File "/home/oscar/.local/share/virtualenvs/games-vv6Brqdh/lib/python3.11/site-packages/socketio/async_server.py", line 607, in _handle_event_internal
    r = await server._trigger_event(data[0], namespace, sid, *data[1:])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/oscar/.local/share/virtualenvs/games-vv6Brqdh/lib/python3.11/site-packages/socketio/async_server.py", line 634, in _trigger_event
    ret = await handler(*args)
          ^^^^^^^^^^^^^^^^^^^^
  File "/home/oscar/games/classquiz/socket_server/__init__.py", line 570, in submit_answer
    latency = int(float((await sio.get_session(sid))["ping"]))
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'ping'
```

This PR fixes the issue by adding a Fallback Mechanism setting latency equal to zero. The ping key is not defined.