### PR TITLE
Add Image-Based Answer Options to Activity View and Practice Routes

### DIFF
--- a/frontend/src/lib/practice/title_screen.svelte
+++ b/frontend/src/lib/practice/title_screen.svelte
@@ -61,15 +61,15 @@ SPDX-License-Identifier: MPL-2.0
 		</div>
 		<div class="dark:bg-gray-700">
 			<div class="flex justify-center pt-10 w-full">
-				<p
-					class="p-3 rounded-lg border-gray-500 border text-center w-11/12 lg:w-1/3 text-lg font-semibold dark:bg-gray-500"
+				<h1
+					class="text-4xl text-center text-[#0056BD] dark:text-[#fff] my-2 font-bold"
 				>
 					{@html data.title}
-				</p>
+			</h1>
 			</div>
-			<div class="flex justify-center pt-10 w-full max-h-32">
+			<div class="flex justify-center pt-10 w-full max-h-32 p-5">
 				<p
-					class="p-3 rounded-lg border-gray-500 border text-center w-11/12 lg:w-1/3 h-20 resize-none dark:bg-gray-500"
+					class="text-[#0056BD] dark:text-[#fff] font-medium"
 				>
 					{@html data.description}
 				</p>

--- a/frontend/src/routes/view/[quiz_id]/+page.svelte
+++ b/frontend/src/routes/view/[quiz_id]/+page.svelte
@@ -51,6 +51,7 @@
 		question: string;
 		image?: string;
 		answers: Answer[];
+		ansType: string;
 	}
 
 	interface Answer {
@@ -333,8 +334,14 @@
 												question.type !== QuizQuestionType.VOTING}
 										>
 											<h4 class="text-center text-white">
-												{quiz.questions[index_question].answers[index_answer]
-													.answer}
+												{#if quiz.questions[index_question].ansType !== 'IMAGE'}
+													{quiz.questions[index_question].answers[index_answer].answer}
+												{:else}
+												<MediaComponent 
+													css_classes="inline-block m-auto max-h-[30vh]" 
+													src={quiz.questions[index_question].answers[index_answer].answer}
+												/>
+												{/if}
 											</h4>
 										</div>
 									{/each}
@@ -367,8 +374,14 @@
 										answer.color ?? default_colors[index_answer]
 									)}">
 											<h4 class="text-center ">
-												{quiz.questions[index_question].answers[index_answer]
-													.answer}
+												{#if quiz.questions[index_question].ansType !== 'IMAGE'}
+													{quiz.questions[index_question].answers[index_answer].answer}
+												{:else}
+													<MediaComponent 
+														css_classes="inline-block m-auto max-h-[30vh]" 
+														src={quiz.questions[index_question].answers[index_answer].answer}
+													/>
+												{/if}
 											</h4>
 										</div>
 									{/each}

--- a/frontend/src/routes/view/[quiz_id]/+page.svelte
+++ b/frontend/src/routes/view/[quiz_id]/+page.svelte
@@ -320,14 +320,11 @@
 								<span class="text-lg">{question.time}s</span>
 							</p>
 							{#if question.type === QuizQuestionType.ABCD || question.type === undefined || question.type === QuizQuestionType.CHECK}
-								<div class="grid grid-cols-2 gap-4 m-4 p-6">
+								<div class="grid grid-rows-2 gap-2 w-full grid-cols-2">
 									{#each question.answers as answer, index_answer}
 										<div
-											class="p-1 rounded-lg py-4 "
-											style="background-color: {answer.color ??
-												default_colors[index_answer]}; color: {get_foreground_color(
-												answer.color ?? default_colors[index_answer]
-											)}"
+											class="rounded-lg h-full  flex items-center justify-center disabled:opacity-60 border-4 border-white transition-all my-2 disabled:grayscale text-black"
+											style="background-color: {answer.color ?? default_colors[index_answer]}; color: {get_foreground_color(answer.color ?? default_colors[index_answer])}"
 											class:shadow-blue-500={answer.right &&
 												question.type !== QuizQuestionType.VOTING}
 											class:shadow-yellow-500={!answer.right &&


### PR DESCRIPTION
This PR introduces the ability to display images as answer options on both the quiz view and practice routes. The main updates include:

- Image answer options added to quiz and practice routes
- Adjusted styling for the title and description on the practice route
- Introduced logic to handle both text and image answer types
- Minor style adjustments for better UI consistency