### PR TITLE
Display Images on Check Choice Questions and Results

### DIFF
--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -533,11 +533,29 @@
 				{#if selected_answer !== undefined && selected_answer !== ''}	
 					<p class="text-lg font-semibold text-[#00529B] dark:text-[#fff] mt-10">Your answer:</p>
 					{#if Array.isArray(selected_answer)}
-					<ul class="list-disc list-inside mx-auto text-left text-[#00529B] inline-block dark:text-[#fff]">
-						{#each selected_answer as ans}
-						<li class="text-lg">{ans}</li>
-						{/each}
-					</ul>
+						{#if question.ansType === "IMAGE"}
+							<div class="w-full flex justify-center">
+								<div class='grid grid-rows-2 gap-2 w-3/5 h-full grid-flow-col auto-cols-auto justify-center items-center'>
+									{#each selected_answer as ans}
+										<div
+											class="rounded-lg flex items-center justify-center disabled:opacity-60 border-2 border-black transition-all my-2 dark:border-white"
+										>
+											<MediaComponent 
+												css_classes="w-full h-full object-contain" 
+												bind:src={ans}
+												allow_fullscreen={false}
+											/>
+										</div>
+									{/each}
+								</div>
+							</div>
+						{:else}
+							<ul class="list-disc list-inside mx-auto text-left text-[#00529B] inline-block dark:text-[#fff]">
+								{#each selected_answer as ans}
+								<li class="text-lg">{ans}</li>
+								{/each}
+							</ul>
+						{/if}
 					{:else}
 						{#if question.ansType === "IMAGE"}
 							<MediaComponent 

--- a/frontend/src/lib/play/questions/check.svelte
+++ b/frontend/src/lib/play/questions/check.svelte
@@ -4,8 +4,8 @@
 	import { get_foreground_color } from '$lib/helpers';
 	import { kahoot_icons } from '$lib/play/kahoot_mode_assets/kahoot_icons';
 	import CircularTimer from '$lib/play/circular_progress.svelte';
-	import BrownButton from '$lib/components/buttons/brown.svelte';
 	import RightArrow from '$lib/icons/rightArrow.svelte';
+	import MediaComponent from '$lib/editor/MediaComponent.svelte';
 
 	const default_colors = ['#C8E6C9', '#FFE0B2', '#FFF9C4', '#B3E5FC'];
 	export let question: Question;
@@ -84,9 +84,25 @@
 						class:opacity-50={!_selected_answers[i]}
 					>
 						{#if game_mode === 'kahoot'}
-							<img class="inline-block m-auto max-h-[30vh]" alt="Icon" src={kahoot_icons[i]} />
+							{#if question.ansType === 'IMAGE'}
+								<MediaComponent 
+									css_classes="inline-block m-auto max-h-[30vh]" 
+									bind:src={answer.answer} 
+									allow_fullscreen={false}
+								/>
+							{:else}
+								<img class="inline-block m-auto max-h-[30vh]" alt="Icon" src={kahoot_icons[i]} />
+							{/if}
 						{:else}
-							<p class="m-auto button-text text-sm sm:text-base md:text-lg lg:text-xl" style="color: {getTextColor(answer.color ?? '#004A93')}">{answer.answer}</p>
+							{#if question.ansType === 'IMAGE'}
+								<MediaComponent 
+									css_classes="inline-block m-auto max-h-[30vh]" 
+									bind:src={answer.answer}
+									allow_fullscreen={false} 
+								/>
+							{:else}
+								<p class="m-auto button-text text-sm sm:text-base md:text-lg lg:text-xl" style="color: {getTextColor(answer.color ?? '#004A93')}">{answer.answer}</p>
+							{/if}
 						{/if}
 					</button>
 				{/each}


### PR DESCRIPTION
- Added support for displaying images in check choice questions.
- Updated the UI to show image answers using `MediaComponent` on both check choice questions and result displays.
- Enhanced conditional rendering logic for answers with image types, ensuring images are correctly displayed or default icons are shown when appropriate.
- Cleaned up duplicate code for displaying text or images in response areas.
