### PR TITLE
Fix scrolling issue on mobile devices for order-type questions

### DIFF
--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -407,15 +407,19 @@
 				class="fixed top-0 bg-red-500 h-8 transition-all"
 				style="width: {(100 / parseInt(question.time)) * parseInt(timer_res)}vw"
 			/>
-			<div class="flex flex-col items-center justify-center w-full min-h-screen gap-4 px-4 mt-2">
+			<div
+				class="flex flex-col items-center justify-start w-full min-h-screen gap-4 px-4 mt-2"
+				style="overflow-y: auto; -webkit-overflow-scrolling: touch;"
+			>
 				{#each question.answers as answer, i (i)}
 					<div
 						class="w-full h-fit flex-row rounded-lg p-2 align-middle"
 						animate:flip={{ duration: 100 }}
 						style="color: {getTextColor(answer.color ?? '#004A93')}; background-color: {answer.color ?? '#004A93'};"
 					>
+						<!-- svelte-ignore redundant-event-modifier -->
 						<button
-							on:click={() => {
+							on:click|passive={() => {
 								question.answers = swapArrayElements(question.answers, i, i - 1);
 							}}
 							class="disabled:opacity-50 transition shadow-lg bg-black text-white bg-opacity-30 w-full flex justify-center rounded-lg p-2 hover:bg-opacity-20 transition"
@@ -442,9 +446,9 @@
 						<p class="w-full text-center p-2 text-2xl text-white">
 							{answer.answer}
 						</p>
-
+						<!-- svelte-ignore redundant-event-modifier -->
 						<button
-							on:click={() => {
+							on:click|passive={() => {
 								question.answers = swapArrayElements(question.answers, i, i + 1);
 							}}
 							class="disabled:opacity-50 transition shadow-lg bg-black text-white bg-opacity-30 w-full flex justify-center rounded-lg p-2 hover:bg-opacity-20 transition"


### PR DESCRIPTION
**Problem:**
Users on mobile devices, especially iPhones, are experiencing difficulty scrolling down to the submit button in order-type questions (`QuizQuestionType.ORDER`). When they attempt to scroll by touching over the answer elements (divs, buttons, or SVGs), the page doesn't scroll. This is because touch events on these interactive elements prevent the default scrolling behavior, making it challenging or impossible for users to access the submit button and submit their answers.

**Cause:**
On iOS devices, interactive elements like buttons with touch event listeners can interfere with the default scrolling mechanism. When a user touches these elements, the touch events are captured, and if not properly configured, they can block the scrolling action. Additionally, using `justify-center` in the flex container can cause content not to extend beyond the viewport, preventing scrolling.

**Solution:**
This PR implements the following changes to resolve the scrolling issue:

1. **Adjust Flex Container Alignment and Enable Scrolling:**
   - **Change `justify-center` to `justify-start`:**
     - Before:
       ```svelte
       <div class="flex flex-col items-center justify-center w-full min-h-screen gap-4 px-4 mt-2">
       ```
     - After:
       ```svelte
       <div
         class="flex flex-col items-center justify-start w-full min-h-screen gap-4 px-4 mt-2"
         style="overflow-y: auto; -webkit-overflow-scrolling: touch;"
       >
       ```
     - This change allows the content to expand beyond the viewport, enabling vertical scrolling.

   - **Add Scrolling Styles:**
     - `overflow-y: auto;` allows the container to scroll vertically when content overflows.
     - `-webkit-overflow-scrolling: touch;` enables smooth scrolling on iOS devices.

2. **Add Passive Event Listeners to Buttons:**
   - **Modify `on:click` Event Listeners with `|passive` Modifier:**
     - Before:
       ```svelte
       <button
         on:click={() => {
           question.answers = swapArrayElements(question.answers, i, i - 1);
         }}
         ...
       >
       ```
     - After:
       ```svelte
       <!-- svelte-ignore redundant-event-modifier -->
       <button
         on:click|passive={() => {
           question.answers = swapArrayElements(question.answers, i, i - 1);
         }}
         ...
       >
       ```
     - The `|passive` modifier indicates that the event listener will not call `event.preventDefault()`, ensuring that the default scroll behavior is not blocked when users touch these elements.
     - Added `<!-- svelte-ignore redundant-event-modifier -->` to suppress any Svelte warnings about redundant modifiers.

**Why This PR Solves the Issue:**
By adjusting the flex container alignment and enabling vertical scrolling, the content now extends beyond the viewport, allowing users to scroll through the entire content. The passive event listeners ensure that touch interactions with buttons do not interfere with scrolling. As a result, users on mobile devices can scroll down to the submit button regardless of where they initiate the touch, ensuring they can complete and submit their answers in order-type questions.