### PR TITLE
Correct Participant Counting in Admin Interface

### DIFF
--- a/frontend/src/lib/play/admin/game_not_started.svelte
+++ b/frontend/src/lib/play/admin/game_not_started.svelte
@@ -43,8 +43,10 @@
 		
 	onMount(() => {
 		socket.on('player_joined', (player) => {
-			players.push(player);
-			toast.push(`${player.username} has joined!`);
+			if (!players.some((p) => p.username === player.username)) {
+				players.push(player);
+				toast.push(`${player.username} has joined!`);
+			}
 		});
 	});
 </script>

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -69,7 +69,9 @@ SPDX-License-Identifier: MPL-2.0
 		success = true;
 	});
 	socket.on('player_joined', (int_data) => {
-		players = [...players, int_data];
+		if (!players.some((player) => player.username === int_data.username)) {
+    		players = [...players, int_data];
+  		}
 	});
 	socket.on('already_registered_as_admin', () => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
Rejoining players were being added multiple times to the player list, causing the admin interface to overestimate the number of participants. This resulted in an inflated expected answer count, leading the admin to wait for answers that would never arrive.

**Solution:**
- Updated the client-side code in both the admin page and the Game Not Started component to check for duplicate players before adding them to the list.
- Now, the system ensures each player is counted only once, even if they rejoin the game.

**Changes:**
- Added a check to prevent duplicate players from being added to the `players` array in both `+page.svelte` and `game_not_started.svelte`.
  
**Impact:**
- The admin interface now accurately reflects the number of participants, ensuring proper count and eliminating the delay caused by waiting for nonexistent answers.