### PR TITLE
Client-Side Fetch Handling and CSS Cleanup

### DIFF
--- a/frontend/src/lib/play/join.svelte
+++ b/frontend/src/lib/play/join.svelte
@@ -40,6 +40,10 @@
 					theme: 'dark'
 				});
 			}
+
+			if (game_pin && game_pin.length > 5) {
+				set_game_pin();
+			}
 		}
 	});
 
@@ -84,6 +88,7 @@
 			console.error('PIN is undefined or empty.');
 			return;
 		}
+
 		let process_var;
 		try {
 			process_var = process;
@@ -91,15 +96,17 @@
 			process_var = { env: { API_URL: undefined } };
 		}
 
-		fetchGameState(game_pin).then((gameState) => {
-			console.log('Game State:', gameState);
-			if (gameState) {
-				if ((gameState.current_question + 1 === gameState.questions_count) && !gameState.question_show) {
-				alert('This session has already ended.');
-				window.location.href = '/play';
+		if (browser) {
+			fetchGameState(game_pin).then((gameState) => {
+				console.log('Game State:', gameState);
+				if (gameState) {
+					if ((gameState.current_question + 1 === gameState.questions_count) && !gameState.question_show) {
+						alert('This session has already ended.');
+						window.location.href = '/play';
+					}
 				}
-			}
-		});
+			});
+		}
 
 		const res = await fetch(
 			`${process_var.env.API_URL ?? ''}/api/v1/quiz/play/check_captcha/${game_pin}`
@@ -128,10 +135,6 @@
 		}
 	};
 
-	$: if (game_pin && game_pin.length > 5) {
-		console.log('Setting game pin');
-		set_game_pin();
-	}
 
 	const setUsername = async () => {
 		if (username.length <= 3 || !game_pin) {
@@ -200,7 +203,7 @@
 		}
 	});
 
-	$: console.log(game_pin, game_pin && game_pin.length > 6);
+	// $: console.log(game_pin, game_pin && game_pin.length > 6);
 	$: game_pin = (game_pin || '').replace(/\D/g, '');
 </script>
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -73,16 +73,6 @@
 
 <style lang="scss">
 
-	html {
-		height: 100%;
-		overflow: hidden;
-	}
-	body {
-		min-height: 100%;
-		margin: 0;
-		padding: 0;
-	}
-
 	:global(html.dark){
 		background-image: url('$lib/assets/all/bg_dark.webp') !important;
 		background-position: start;

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -394,8 +394,6 @@
 
 	let bg_color;
 	$: bg_color = gameData ? gameData.background_color : (darkMode ? '#383838' : '#FFFFFF');
-
-	console.log('Game Meta:', gameMeta);
 	
 	$: language = gameData ? gameData.language_toggle : false;
 	// $: console.log('Language:', language);

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -479,10 +479,3 @@
 		{/if}
 	</div>	
 </div>
-<style>
-	.result-container {
-		box-shadow: 1px 1px 9px #00EDFF, 1px 1px 9px #00EDFF inset; 
-		border-radius: 16px; 
-		border: 4px #fff solid; 
-	}
-</style>


### PR DESCRIPTION
There was a problem getting from the client side the current game state using a fetch request. This was generating that the participant didn't get the latest game state from the server after reconnection and we were only relying on the local storage. After this fix reconnecting and getting the game state should be more smooth.

- **Fixed fetchGameState bug**: Adjusted fetch calls to execute only on the client side, preventing SSR issues with relative URLs.
- **Removed unused CSS**: Cleaned up unused CSS selectors to improve readability and performance.

### Details:
- Moved `set_game_pin` function inside `onMount` lifecycle hook to ensure fetch is called only in the browser, fixing an error where fetch was being called during server-side rendering (SSR).
- Refined logic for fetching game state and handling session end, ensuring smooth client-side operation.
- Removed unused styles and log statements from various `.svelte` files, reducing clutter and improving maintainability.