### PR TITLE
Improve Player Count Calculation to Avoid Duplicate Entries

### DIFF
--- a/classquiz/socket_server/__init__.py
+++ b/classquiz/socket_server/__init__.py
@@ -486,6 +486,15 @@ class _SubmitAnswerData(BaseModel):
     complex_answer: list[_SubmitAnswerDataOrderType] | None
 
 
+async def get_unique_player_count(game_pin: str) -> int:
+    players = await redis.smembers(f"game_session:{game_pin}:players")
+    usernames = set()
+    for player_json in players:
+        player = GamePlayer.parse_raw(player_json)
+        usernames.add(player.username)
+    return len(usernames)
+
+
 @sio.event
 async def submit_answer(sid: str, data: dict):
     now = datetime.now()
@@ -591,7 +600,7 @@ async def submit_answer(sid: str, data: dict):
     answers = await set_answer(
         answers, game_pin=session["game_pin"], data=answer_data, q_index=int(float(data.question_index))
     )
-    player_count = await redis.scard(f"game_session:{session['game_pin']}:players")
+    player_count = await get_unique_player_count(session['game_pin'])
     await sio.emit("player_answer", {})
     if len(answers.__root__) == player_count:
         # await sio.emit(

--- a/frontend/src/lib/admin.svelte
+++ b/frontend/src/lib/admin.svelte
@@ -21,6 +21,7 @@ SPDX-License-Identifier: MPL-2.0
 	export let game_mode: string;
 	export let bg_color: string;
 	export let game_pin: string;
+	export let players;
 
 	const { t } = getLocalization();
 	const default_colors = ['#FFA800', '#FF1D38', '#00A3FF', '#00D749'];
@@ -138,6 +139,7 @@ SPDX-License-Identifier: MPL-2.0
 		{quiz_data}
 		{answer_count} 
 		bind:timer_res
+		bind:players
 		{final_results}
 		{socket}
 		{question_results}

--- a/frontend/src/lib/i18n/locales/de.json
+++ b/frontend/src/lib/i18n/locales/de.json
@@ -258,7 +258,7 @@
         "show_results": "Ergebnisse anzeigen",
         "enter_answer_into_field": "Gib die Antwort in das Eingabefeld ein!",
         "stop_time_and_solutions": "Zeit stoppen und Ergebnisse zeigen",
-        "answers_submitted": "{{answer_count}} Antworten abgegeben",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Antworten abgegeben",
         "request_export_results": "Frage den Ergebnis-Download an",
         "download_export_results": "Ergebnisse herunterladen"
     },

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -264,7 +264,7 @@
         "show_results": "Show results",
         "stop_time_and_solutions": "Stop time and show solutions",
         "enter_answer_into_field": "Enter your answer into the input field!",
-        "answers_submitted": "{{answer_count}} Answers submitted",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Answers submitted",
         "request_export_results": "Request result download",
         "download_export_results": "Download results",
         "export_results": "Export results"

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -220,7 +220,7 @@
         "show_results": "Mostrar los resultados",
         "stop_time_and_solutions": "Detener el tiempo y mostrar los resultados",
         "enter_answer_into_field": "¡Ingresa tu respuesta en el campo de entrada!",
-        "answers_submitted": "{{answer_count}} Respuestas enviadas",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Respuestas enviadas",
         "download_export_results": "Descargar los resultados",
         "request_export_results": "Solicitar la descarga de los resultados"
     },

--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -262,7 +262,7 @@
         "show_results": "Montrer les résultats",
         "stop_time_and_solutions": "Arrêter le temps et montrer des solutions",
         "enter_answer_into_field": "Saisissez votre réponse dans le champ de saisie !",
-        "answers_submitted": "{{answer_count}} Réponses soumises",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Réponses soumises",
         "request_export_results": "Demande de téléchargement des résultats",
         "save_results": "Sauvegarder les résultats",
         "download_export_results": "Télécharger les résultats"

--- a/frontend/src/lib/i18n/locales/hu.json
+++ b/frontend/src/lib/i18n/locales/hu.json
@@ -249,7 +249,7 @@
         "stop_time": "Időzítő leállítása",
         "next_question": "Következő kérdés ({{question}})",
         "stop_time_and_solutions": "Időzítőt megállítása és megoldások megtekintése",
-        "answers_submitted": "{{answer_count}} válasz elküldve",
+        "answers_submitted": "{{answer_count}} / {{players_count}} válasz elküldve",
         "request_export_results": "Eredmények letöltésének igénylése"
     },
     "password_reset_page": {

--- a/frontend/src/lib/i18n/locales/it.json
+++ b/frontend/src/lib/i18n/locales/it.json
@@ -255,7 +255,7 @@
         "request_export_results": "Richiedi il download del risultato",
         "show_results": "Mostra i risultati",
         "enter_answer_into_field": "Inserisci la tua risposta nel campo inserimento!",
-        "answers_submitted": "{{answer_count}} Risposte inviate",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Risposte inviate",
         "download_export_results": "Scarica i risultati",
         "next_question": "Prossima domanda ({{question}})"
     },

--- a/frontend/src/lib/i18n/locales/ja.json
+++ b/frontend/src/lib/i18n/locales/ja.json
@@ -106,7 +106,7 @@
         "next_question": "次の質問 ({{question}})",
         "show_results": "結果を表示",
         "stop_time_and_solutions": "時間を停止し、解決を示す",
-        "answers_submitted": "{{answer_count}} 提出された回答",
+        "answers_submitted": "{{answer_count}} / {{players_count}} 提出された回答",
         "time_left": "時間切れ",
         "save_results": "結果を保存",
         "download_export_results": "結果をダウンロード"

--- a/frontend/src/lib/i18n/locales/nb_NO.json
+++ b/frontend/src/lib/i18n/locales/nb_NO.json
@@ -186,7 +186,7 @@
         "show_results": "Vis resultater",
         "save_results": "Lagre resultat",
         "enter_answer_into_field": "Skriv inn svaret ditt i inndatafeltet.",
-        "answers_submitted": "{{answer_count}} svar innsendt",
+        "answers_submitted": "{{answer_count}} / {{players_count}} svar innsendt",
         "download_export_results": "Last ned resultat",
         "next_question": "Neste spørsmål ({{question}})"
     },

--- a/frontend/src/lib/i18n/locales/nl.json
+++ b/frontend/src/lib/i18n/locales/nl.json
@@ -262,7 +262,7 @@
         "enter_answer_into_field": "Typ je antwoord in het invoerveld!",
         "stop_time_and_solutions": "Stop de tijd en toon oplossingen",
         "download_export_results": "Resultaten downloaden",
-        "answers_submitted": "{{answer_count}} Antwoorden ingediend",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Antwoorden ingediend",
         "request_export_results": "Resultaat download aanvragen"
     },
     "password_reset_page": {

--- a/frontend/src/lib/i18n/locales/pl.json
+++ b/frontend/src/lib/i18n/locales/pl.json
@@ -300,7 +300,7 @@
         "show_results": "Pokaż wyniki",
         "stop_time_and_solutions": "Zatrzymaj czas i pokaż rozwiązania",
         "enter_answer_into_field": "Wprowadź swoją odpowiedź w pole wejściowe!",
-        "answers_submitted": "{{answer_count}} Przesłane odpowiedzi",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Przesłane odpowiedzi",
         "request_export_results": "Żądanie pobrania wyników",
         "download_export_results": "Wyniki pobierania"
     },

--- a/frontend/src/lib/i18n/locales/pt.json
+++ b/frontend/src/lib/i18n/locales/pt.json
@@ -257,7 +257,7 @@
         "enter_answer_into_field": "Insira sua resposta na caixa de texto!",
         "get_results_and_stop_time": "Obter resultados e parar o tempo",
         "start_game": "Iniciar o jogo",
-        "answers_submitted": "{{answer_count}} Respostas enviadas",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Respostas enviadas",
         "download_export_results": "Baixar resultados",
         "next_question": "Próxima pergunta ({{question}})",
         "get_results": "Obter resultados",

--- a/frontend/src/lib/i18n/locales/tr.json
+++ b/frontend/src/lib/i18n/locales/tr.json
@@ -212,7 +212,7 @@
         "start_by_showing_first_question": "İlk soruyu göstererek başla.",
         "no_answers": "Hata! Yanıt göndermediniz. Lütfen sonuçları bekleyin.",
         "stop_time": "Zamanı durdur",
-        "answers_submitted": "{{answer_count}} Gönderilen cevaplar",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Gönderilen cevaplar",
         "request_export_results": "Sonuç indirmeyi talep et",
         "download_export_results": "Sonuçları indir",
         "save_results": "Sonuçları kaydet",

--- a/frontend/src/lib/i18n/locales/vi.json
+++ b/frontend/src/lib/i18n/locales/vi.json
@@ -184,7 +184,7 @@
         "enter_answer_into_field": "Nhập câu trả lời của bạn vào ô nhập dữ liệu!",
         "get_results_and_stop_time": "Nhận kết quả và dừng thời gian",
         "start_game": "Bắt đầu game",
-        "answers_submitted": "{{answer_count}} Câu trả lời đã được gửi",
+        "answers_submitted": "{{answer_count}} / {{players_count}} Câu trả lời đã được gửi",
         "download_export_results": "Tải xuống kết quả",
         "next_question": "Câu hỏi tiếp theo ({{question}})",
         "get_results": "Xem kết quả",

--- a/frontend/src/lib/play/admin/controls.svelte
+++ b/frontend/src/lib/play/admin/controls.svelte
@@ -22,6 +22,7 @@ SPDX-License-Identifier: MPL-2.0
 	export let game_token: string;
 	export let game_pin: string;
 	export let question_results;
+	export let players;
 
 	export let shown_question_now: number;
 	let fullscreen_open = false;
@@ -119,7 +120,7 @@ SPDX-License-Identifier: MPL-2.0
 		<div
 			class="fixed right-0 top-20 lg:text-sm text-xs px-4 py-2 mr-3 mt-4 rounded-xl text-white bg-black bg-opacity-20 shadow-lg"
 		>
-			{$t('admin_page.answers_submitted', { answer_count: answer_count })}
+		{$t('admin_page.answers_submitted', { answer_count: answer_count, players_count: players.length })}
 		</div>
 		{#if selected_question + 1 != quiz_data.questions.length}
 			{#if question_results === null}

--- a/frontend/src/lib/play/admin/game_not_started.svelte
+++ b/frontend/src/lib/play/admin/game_not_started.svelte
@@ -46,6 +46,8 @@
 			if (!players.some((p) => p.username === player.username)) {
 				players.push(player);
 				toast.push(`${player.username} has joined!`);
+				console.log('New player joined:', player);
+				console.log('Players:',players);
 			}
 		});
 	});

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -71,6 +71,8 @@ SPDX-License-Identifier: MPL-2.0
 	socket.on('player_joined', (int_data) => {
 		if (!players.some((player) => player.username === int_data.username)) {
     		players = [...players, int_data];
+			console.log('New player joined:',int_data);
+			console.log('Players:',players);
   		}
 	});
 	socket.on('already_registered_as_admin', () => {
@@ -217,6 +219,7 @@ SPDX-License-Identifier: MPL-2.0
 				bind:bg_color
 				bind:player_scores
 				bind:control_visible
+				bind:players
 			/>
 		{/if}
 	</div>


### PR DESCRIPTION
This PR addresses the issue where the player count could be incorrectly inflated due to players rejoining the game with a new session ID (sid). Previously, the player count was calculated using the Redis `scard` function, which counts all player entries, including those from reconnections.

### Changes:
- Introduced a helper function `get_unique_player_count` to calculate the number of unique players based on their usernames, ensuring that reconnections do not affect the player count.
- Updated the `submit_answer` function to use this helper function when calculating the `player_count`, ensuring accurate answer tracking based on unique participants.

### Affected Files:
- **Backend**: `classquiz/socket_server/__init__.py`
  - Added `get_unique_player_count` to count unique players.
  - Updated `submit_answer` to utilize this new method for accurate player count.
  
- **Frontend**: Updated i18n strings to reflect the new "answers submitted" format that includes both answer and player counts in various languages.

This change ensures that player count is not inflated due to multiple session IDs from the same player, which improves the accuracy of answer submission and game flow.
