### PR TITLE
Ensure Socket Reconnection After iPhone Lock/Unlock & Add Missing Game Parameters to Game State

### DIFF
--- a/classquiz/routers/game_state.py
+++ b/classquiz/routers/game_state.py
@@ -14,8 +14,11 @@ async def fetch_game_state(game_pin: str):
     data = PlayGame.parse_raw(data_redis_res)
     print(data)
     return {
+        "quiz_id": data.quiz_id,
+        "game_id": data.game_id,
         "game_pin": data.game_pin,
         "started": data.started,
+        "game_mode": data.game_mode,
         "current_question": data.current_question,
         "questions_count": len(data.questions),
         "title": data.title,
@@ -23,5 +26,6 @@ async def fetch_game_state(game_pin: str):
         "cover_image": data.cover_image,
         "background_color": data.background_color,
         "background_image": data.background_image,
-        "question_show": data.question_show
+        "question_show": data.question_show,
+        "language_toggle": data.language_toggle
     }

--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -4,4 +4,13 @@
 
 import { io } from 'socket.io-client';
 
-export const socket = io();
+export const socket = io(
+    {
+        reconnection: true,             // Enable reconnection
+        reconnectionAttempts: Infinity, // Retry forever
+        reconnectionDelay: 1000,        // Start with a 1-second delay
+        reconnectionDelayMax: 5000,     // Maximum delay of 5 seconds
+        transports: ['websocket'],      // Use WebSocket transport
+        autoConnect: true,              // Automatically connect on creation
+    }
+);


### PR DESCRIPTION
This PR addresses the issue of Socket.IO disconnection on iPhone devices when the screen locks and resumes. It ensures that the socket connection is properly re-established when the participant unlocks the phone and returns to the activity.

**Key Changes:**

1. **Socket Reconnection for iPhone Hibernate:**
   - Implemented socket reconnection logic in `socket.ts` using `Socket.IO` options, including infinite reconnection attempts and delays.
   - Added `visibilitychange` event listener in the Svelte page to trigger a reconnection attempt when the user unlocks the device or returns to the page after it was hidden.
   - Rejoin the activity session upon successful reconnection to ensure continuity for the participant.

2. **Game State Endpoint Update:**
   - Added missing parameters to the `/game_state` endpoint to provide more comprehensive activity data.

**Files Changed:**
- `frontend/src/lib/socket.ts`: Enhanced Socket.IO configuration for better reconnection behavior.
- `frontend/src/routes/play/+page.svelte`: Added event listeners to handle reconnections when the visibility changes.
- `classquiz/routers/game_state.py`: Added fields to the game state response.

This update should improve the user experience by ensuring that the activity remains accessible even after temporary disconnection events due to phone inactivity.