### PR TITLE
Disable fullscreen mode for image options

### DIFF
--- a/frontend/src/lib/play/question.svelte
+++ b/frontend/src/lib/play/question.svelte
@@ -291,6 +291,7 @@
 								{#if question.ansType === 'IMAGE'}
 									<MediaComponent 
 										css_classes="inline-block m-auto max-h-[30vh]" 
+										allow_fullscreen={false}
 										src={answer.answer} 
 									/>
 								{:else}
@@ -300,6 +301,7 @@
 								{#if question.ansType === 'IMAGE'}
 									<MediaComponent 
 										css_classes="inline-block m-auto max-h-[30vh]" 
+										allow_fullscreen={false}
 										src={answer.answer} 
 									/>
 								{:else}

--- a/frontend/src/lib/play/title.svelte
+++ b/frontend/src/lib/play/title.svelte
@@ -53,14 +53,14 @@ SPDX-License-Identifier: MPL-2.0
 		<div class="flex justify-center align-middle items-center">		
 			{#if contentType?.startsWith('image')}
 				<img
-					css_classes="max-h-[35vh] object-cover mx-auto mb-1 w-auto"
+					class="max-h-[35vh] object-cover mx-auto mb-1 w-auto"
 					src={`/api/v1/storage/download/${cover_image}`}
 					alt="Not provided"
 				/>
 			{:else if contentType?.startsWith('video')}
 				<!-- svelte-ignore a11y-media-has-caption -->
 				<video
-					css_classes="max-h-[35vh] object-cover mx-auto mb-1 w-auto"
+					class="max-h-[35vh] object-cover mx-auto mb-1 w-auto"
 					src={getVideoUrl(`/api/v1/storage/download/${cover_image}`)}
 					controls
 					autoplay={false}


### PR DESCRIPTION
This PR implements:
1. Disable Fullscreen mode for image options on participant's screen.
2. Fix image class not working when on title screen. changed "css_classes" to "class". 