### PR TITLE
Send scores form the server when showing final results

### DIFF
--- a/classquiz/routers/game_state.py
+++ b/classquiz/routers/game_state.py
@@ -10,9 +10,9 @@ async def fetch_game_state(game_pin: str):
     data_redis_res = await redis.get(f"game:{game_pin}")
     if data_redis_res is None:
         raise HTTPException(status_code=404, detail="Game not found or API key not found")
-    
+
     data = PlayGame.parse_raw(data_redis_res)
-    print(data)
+
     return {
         "game_pin": data.game_pin,
         "started": data.started,

--- a/classquiz/socket_server/__init__.py
+++ b/classquiz/socket_server/__init__.py
@@ -644,7 +644,15 @@ async def get_final_results(sid: str, _data: dict):
     if not session["admin"]:
         return
     results = await generate_final_results(game_data, session["game_pin"])
-    await sio.emit("final_results", results, room=session["game_pin"])
+    player_scores = await redis.hgetall(f"game_session:{session['game_pin']}:player_scores")
+    await sio.emit(
+        "final_results",
+        {
+            "results": results,
+            "player_scores": player_scores
+        },
+        room=session["game_pin"]
+    )
 
 
 @sio.event

--- a/frontend/src/routes/play/+page.svelte
+++ b/frontend/src/routes/play/+page.svelte
@@ -189,7 +189,10 @@
 
 	function handleFinalResults(data) {
 		console.log('Final results:', data);
-		final_results = data;
+		final_results = data.results;
+		let converted_scores =  Object.fromEntries(Object.entries(data.player_scores).map(([key, value]) => [key, Number(value)])); // This statement converts string values to numbers in an object
+		scores = converted_scores;
+		console.log('Final scores:', scores);
 		gameEnded = true;
 		clearState();  // Clear state when the game ends
 		if (browser) {


### PR DESCRIPTION
There was a problem when the participant was disconnected and rejoined the game at the end and the scores were not updated.

This PR ensures the scores are sent from the server when presenting the final results.